### PR TITLE
feat: order-service 장바구니 아이템 추가 API 멱등성 보장

### DIFF
--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/api/CartRequests.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/api/CartRequests.kt
@@ -13,11 +13,14 @@ data class AddCartItemRequest(
     @field:NotNull
     @field:Positive
     val qty: Int,
+
+    val idempotencyKey: String? = null,
 ) {
     fun toCommand(userId: Long): AddCartItemCommand = AddCartItemCommand(
         userId = userId,
         skuId = skuId,
         qty = qty,
+        idempotencyKey = idempotencyKey,
     )
 }
 

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/application/command/CartCommands.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/application/command/CartCommands.kt
@@ -1,6 +1,6 @@
 package com.koosco.orderservice.application.command
 
-data class AddCartItemCommand(val userId: Long, val skuId: Long, val qty: Int)
+data class AddCartItemCommand(val userId: Long, val skuId: Long, val qty: Int, val idempotencyKey: String? = null)
 
 data class UpdateCartItemCommand(val userId: Long, val cartItemId: Long, val qty: Int)
 

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/application/port/CartIdempotencyRepository.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/application/port/CartIdempotencyRepository.kt
@@ -1,0 +1,10 @@
+package com.koosco.orderservice.application.port
+
+import com.koosco.orderservice.domain.entity.CartIdempotency
+
+interface CartIdempotencyRepository {
+
+    fun findByUserIdAndIdempotencyKey(userId: Long, idempotencyKey: String): CartIdempotency?
+
+    fun save(entry: CartIdempotency): CartIdempotency
+}

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/application/usecase/AddCartItemUseCase.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/application/usecase/AddCartItemUseCase.kt
@@ -2,21 +2,44 @@ package com.koosco.orderservice.application.usecase
 
 import com.koosco.common.core.annotation.UseCase
 import com.koosco.orderservice.application.command.AddCartItemCommand
+import com.koosco.orderservice.application.port.CartIdempotencyRepository
 import com.koosco.orderservice.application.port.CartRepository
 import com.koosco.orderservice.application.result.CartItemResult
 import com.koosco.orderservice.domain.entity.Cart
+import com.koosco.orderservice.domain.entity.CartIdempotency
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-class AddCartItemUseCase(private val cartRepository: CartRepository) {
+class AddCartItemUseCase(
+    private val cartRepository: CartRepository,
+    private val cartIdempotencyRepository: CartIdempotencyRepository,
+) {
 
     @Transactional
     fun execute(command: AddCartItemCommand): CartItemResult {
+        if (command.idempotencyKey != null) {
+            val existing = cartIdempotencyRepository.findByUserIdAndIdempotencyKey(
+                command.userId,
+                command.idempotencyKey,
+            )
+            if (existing != null) {
+                val cart = cartRepository.findByUserId(command.userId)
+                val item = cart?.items?.find { it.id == existing.cartItemId }
+                if (item != null) return CartItemResult.from(item)
+            }
+        }
+
         val cart = cartRepository.findByUserId(command.userId)
             ?: cartRepository.save(Cart.create(command.userId))
 
         val item = cart.addItem(command.skuId, command.qty)
         cartRepository.save(cart)
+
+        if (command.idempotencyKey != null) {
+            cartIdempotencyRepository.save(
+                CartIdempotency.create(command.userId, command.idempotencyKey, item.id!!),
+            )
+        }
 
         return CartItemResult.from(item)
     }

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/domain/entity/CartIdempotency.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/domain/entity/CartIdempotency.kt
@@ -1,0 +1,46 @@
+package com.koosco.orderservice.domain.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.Instant
+
+@Entity
+@Table(
+    name = "cart_idempotency",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uq_cart_idempotency_user_key",
+            columnNames = ["user_id", "idempotency_key"],
+        ),
+    ],
+    indexes = [
+        Index(name = "idx_cart_idempotency_item", columnList = "cart_item_id"),
+    ],
+)
+class CartIdempotency(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+    @Column(name = "user_id", nullable = false)
+    val userId: Long,
+    @Column(name = "idempotency_key", nullable = false, length = 100)
+    val idempotencyKey: String,
+    @Column(name = "cart_item_id", nullable = false)
+    val cartItemId: Long,
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: Instant = Instant.now(),
+) {
+    companion object {
+        fun create(userId: Long, idempotencyKey: String, cartItemId: Long): CartIdempotency = CartIdempotency(
+            userId = userId,
+            idempotencyKey = idempotencyKey,
+            cartItemId = cartItemId,
+        )
+    }
+}

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/infra/persist/CartIdempotencyRepositoryAdapter.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/infra/persist/CartIdempotencyRepositoryAdapter.kt
@@ -1,0 +1,14 @@
+package com.koosco.orderservice.infra.persist
+
+import com.koosco.orderservice.application.port.CartIdempotencyRepository
+import com.koosco.orderservice.domain.entity.CartIdempotency
+import org.springframework.stereotype.Repository
+
+@Repository
+class CartIdempotencyRepositoryAdapter(private val jpaRepository: JpaCartIdempotencyRepository) :
+    CartIdempotencyRepository {
+    override fun findByUserIdAndIdempotencyKey(userId: Long, idempotencyKey: String) =
+        jpaRepository.findByUserIdAndIdempotencyKey(userId, idempotencyKey)
+
+    override fun save(entry: CartIdempotency) = jpaRepository.save(entry)
+}

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/infra/persist/JpaCartIdempotencyRepository.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/infra/persist/JpaCartIdempotencyRepository.kt
@@ -1,0 +1,8 @@
+package com.koosco.orderservice.infra.persist
+
+import com.koosco.orderservice.domain.entity.CartIdempotency
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaCartIdempotencyRepository : JpaRepository<CartIdempotency, Long> {
+    fun findByUserIdAndIdempotencyKey(userId: Long, idempotencyKey: String): CartIdempotency?
+}


### PR DESCRIPTION
## Summary
- CartIdempotency 엔티티 + 리포지토리 인프라 추가 (unique constraint: user_id + idempotency_key)
- AddCartItemUseCase에 멱등성 체크 로직 적용
- AddCartItemRequest/Command에 optional `idempotencyKey` 필드 추가

## 문제점
기존 `Cart.addItem()`은 upsert 방식으로, 동일 SKU 재요청 시 수량이 누적됨:
```
1차 요청: qty=2 → CartItem(skuId=100, qty=2)
재시도:   qty=2 → CartItem(skuId=100, qty=4)  ← 의도치 않은 이중 증가
```

## 해결
idempotencyKey가 있으면 이전 처리 결과를 반환하여 이중 증가 방지:
```
1차 요청: qty=2, key="abc" → CartItem(skuId=100, qty=2)
재시도:   qty=2, key="abc" → CartItem(skuId=100, qty=2)  ← 동일 결과 반환
```

## Test plan
- [ ] idempotencyKey 없이 아이템 추가 → 기존 upsert 동작 유지
- [ ] idempotencyKey와 함께 첫 호출 → 정상 추가
- [ ] 동일 idempotencyKey로 재호출 → 기존 결과 반환, 수량 이중 증가 없음

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)