### PR TITLE
fix: payment-service RestClient timeout 설정 추가

### DIFF
--- a/services/payment-service/src/main/kotlin/com/koosco/paymentservice/infra/config/RestClientConfig.kt
+++ b/services/payment-service/src/main/kotlin/com/koosco/paymentservice/infra/config/RestClientConfig.kt
@@ -1,15 +1,29 @@
 package com.koosco.paymentservice.infra.config
 
+import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.web.client.RestClient
+import java.time.Duration
+
+@ConfigurationProperties(prefix = "payment.client")
+data class PaymentClientProperties(
+    val connectTimeout: Duration = Duration.ofSeconds(5),
+    val readTimeout: Duration = Duration.ofSeconds(5),
+)
 
 @Configuration
 class RestClientConfig {
 
-    /**
-     * timeout, interceptor, header 설정 가능
-     */
     @Bean
-    fun portOneRestClient(): RestClient = RestClient.create()
+    fun portOneRestClient(properties: PaymentClientProperties): RestClient {
+        val factory = SimpleClientHttpRequestFactory().apply {
+            setConnectTimeout(properties.connectTimeout)
+            setReadTimeout(properties.readTimeout)
+        }
+        return RestClient.builder()
+            .requestFactory(factory)
+            .build()
+    }
 }

--- a/services/payment-service/src/main/resources/application.yaml
+++ b/services/payment-service/src/main/resources/application.yaml
@@ -59,6 +59,9 @@ jwt:
   refresh-expiration: ${JWT_REFRESH_EXPIRATION:604800} # 7 days in seconds
 
 payment:
+  client:
+    connect-timeout: 5s
+    read-timeout: 5s
   topic:
     default: koosco.commerce.integration.order
     mappings:


### PR DESCRIPTION
## Summary
- payment-service의 `RestClient`에 connect/read timeout(각 5초)을 설정하여, 외부 결제 API(Toss Payments) 응답 지연 시 Tomcat 스레드가 무한 대기하는 문제를 방지합니다.
- `PaymentClientProperties`를 통해 timeout 값을 `application.yaml`에서 설정 가능하도록 외부화했습니다.

## Changes
- `RestClientConfig.kt`: `SimpleClientHttpRequestFactory`에 connectTimeout/readTimeout 적용, `PaymentClientProperties` 추가
- `application.yaml`: `payment.client.connect-timeout`, `payment.client.read-timeout` 속성 추가 (기본값 5s)

## Test plan
- [ ] payment-service 정상 기동 확인
- [ ] RestClient bean이 timeout이 설정된 factory를 사용하는지 확인
- [ ] timeout 값 변경 시 정상 반영되는지 확인

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)