### PR TITLE
fix: order-service refundItem() 상태 검증 조건 반전 및 refundAll() 이중 호출 수정

### DIFF
--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/domain/entity/OrderItem.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/domain/entity/OrderItem.kt
@@ -1,9 +1,12 @@
 package com.koosco.orderservice.domain.entity
 
+import com.koosco.orderservice.domain.enums.OrderItemStatus
 import com.koosco.orderservice.domain.vo.Money
 import com.koosco.orderservice.domain.vo.OrderItemSpec
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -51,6 +54,14 @@ class OrderItem(
     @Column(nullable = false)
     val lineAmount: Money,
 
+    /** 환불 가능 금액 (주문 시점에 고정) */
+    @Column(nullable = false)
+    val refundableAmount: Money,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var status: OrderItemStatus = OrderItemStatus.ORDERED,
+
     @Column(nullable = false, updatable = false)
     val createdAt: LocalDateTime = LocalDateTime.now(),
 ) {
@@ -65,6 +76,13 @@ class OrderItem(
             qty = spec.quantity,
             unitPrice = spec.unitPrice,
             lineAmount = spec.totalPrice(),
+            refundableAmount = spec.totalPrice(),
         )
+    }
+
+    fun refund(): Money {
+        check(status == OrderItemStatus.ORDERED) { "이미 환불된 아이템입니다. itemId=$id" }
+        status = OrderItemStatus.REFUNDED
+        return refundableAmount
     }
 }

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/domain/enums/OrderItemStatus.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/domain/enums/OrderItemStatus.kt
@@ -1,0 +1,9 @@
+package com.koosco.orderservice.domain.enums
+
+enum class OrderItemStatus {
+    /** 주문됨 */
+    ORDERED,
+
+    /** 환불됨 */
+    REFUNDED,
+}

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/domain/enums/OrderStatus.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/domain/enums/OrderStatus.kt
@@ -19,6 +19,12 @@ enum class OrderStatus {
     /** 재고 확정 차감 완료 */
     CONFIRMED,
 
+    /** 부분 환불 */
+    PARTIALLY_REFUNDED,
+
+    /** 전체 환불 */
+    REFUNDED,
+
     /** 결제 취소 */
     CANCELLED,
 


### PR DESCRIPTION
## Summary
- `refundItem()`에서 환불 가능 상태(PAID, CONFIRMED, PARTIALLY_REFUNDED)일 때 예외를 던지던 조건 반전 버그 수정
- `refundAll()`에서 `item.refund()`와 `refundItem()` 이중 호출로 인한 이미 환불된 아이템 재환불 시도 버그 수정
- 환불 도메인 모델 구현: `OrderItemStatus` enum, `OrderItem.refund()`, `Order.refundItem()/refundAll()`, `PARTIALLY_REFUNDED`/`REFUNDED` 상태 추가

Closes #17

## Test plan
- [ ] `refundItem()` 호출 시 PAID/CONFIRMED/PARTIALLY_REFUNDED 상태에서 정상 환불 확인
- [ ] `refundItem()` 호출 시 그 외 상태에서 `InvalidOrderStatus` 예외 발생 확인
- [ ] `refundAll()` 호출 시 모든 아이템이 한 번만 환불되는지 확인
- [ ] 부분 환불 시 `PARTIALLY_REFUNDED`, 전체 환불 시 `REFUNDED` 상태 전이 확인
- [ ] 이미 환불된 아이템에 대한 재환불 시도 시 예외 발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)