### PR TITLE
fix: inventory-service Redis timeout 및 connection pool 설정 추가

### DIFF
--- a/services/inventory-service/build.gradle.kts
+++ b/services/inventory-service/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
 
     // redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("org.apache.commons:commons-pool2")
 
     // kafka
     implementation("org.springframework.kafka:spring-kafka")

--- a/services/inventory-service/src/main/resources/application.yaml
+++ b/services/inventory-service/src/main/resources/application.yaml
@@ -33,6 +33,13 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD:}
+      timeout: 3s
+      lettuce:
+        pool:
+          max-active: 10
+          max-idle: 5
+          min-idle: 2
+          max-wait: 3s
 
   datasource:
     url: jdbc:mariadb://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:commerce-inventory}


### PR DESCRIPTION
## Summary
- inventory-service의 Redis에 timeout(3s) 및 Lettuce connection pool 설정 추가
- Lettuce pool 사용을 위해 `commons-pool2` 의존성 추가
- Redis 장애 시 기본 60초 대기를 3초로 단축하여 thread blocking 방지

## Changes
### `application.yaml`
- `spring.data.redis.timeout: 3s` -- 커넥션/커맨드 타임아웃
- `spring.data.redis.lettuce.pool` -- max-active: 10, max-idle: 5, min-idle: 2, max-wait: 3s

### `build.gradle.kts`
- `org.apache.commons:commons-pool2` 의존성 추가 (Lettuce pool 활성화에 필수)

## Test plan
- [ ] inventory-service 정상 기동 확인
- [ ] Redis 연결 후 재고 예약/확정/취소 동작 확인
- [ ] Redis 장애 시 3초 내 타임아웃 발생 확인

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)