### PR TITLE
feat: order-service/payment-service 환불 Kafka 이벤트 연동

### DIFF
--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/api/RefundOrderItemsRequest.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/api/RefundOrderItemsRequest.kt
@@ -1,0 +1,15 @@
+package com.koosco.orderservice.api
+
+import com.koosco.orderservice.application.command.RefundOrderItemsCommand
+import jakarta.validation.constraints.NotEmpty
+
+data class RefundOrderItemsRequest(
+    @field:NotEmpty
+    val itemIds: List<Long>,
+) {
+    fun toCommand(orderId: Long, userId: Long): RefundOrderItemsCommand = RefundOrderItemsCommand(
+        orderId = orderId,
+        userId = userId,
+        itemIds = itemIds,
+    )
+}

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/api/RefundOrderItemsResponse.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/api/RefundOrderItemsResponse.kt
@@ -1,0 +1,20 @@
+package com.koosco.orderservice.api
+
+import com.koosco.orderservice.application.result.RefundOrderItemsResult
+import com.koosco.orderservice.domain.enums.OrderStatus
+
+data class RefundOrderItemsResponse(
+    val orderId: Long,
+    val refundAmount: Long,
+    val refundedItemIds: List<Long>,
+    val orderStatus: OrderStatus,
+) {
+    companion object {
+        fun from(result: RefundOrderItemsResult): RefundOrderItemsResponse = RefundOrderItemsResponse(
+            orderId = result.orderId,
+            refundAmount = result.refundAmount,
+            refundedItemIds = result.refundedItemIds,
+            orderStatus = result.orderStatus,
+        )
+    }
+}

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/application/command/OrderCommands.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/application/command/OrderCommands.kt
@@ -47,3 +47,13 @@ data class CancelOrderCommand(val orderId: Long, val reason: OrderCancelReason)
  * 주문 실패 처리 command (재고 예약 실패 등 초기 단계 실패)
  */
 data class MarkOrderFailedCommand(val orderId: Long, val reason: String)
+
+/**
+ * 주문 아이템 환불 command
+ */
+data class RefundOrderItemsCommand(val orderId: Long, val userId: Long, val itemIds: List<Long>)
+
+/**
+ * 결제 취소 완료 처리 command (PaymentCanceledEvent 수신 시)
+ */
+data class MarkRefundCompletedCommand(val orderId: Long, val canceledAmount: Long, val isFullyCanceled: Boolean)

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/application/result/OrderResults.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/application/result/OrderResults.kt
@@ -88,6 +88,16 @@ data class OrderDetailResult(
     }
 }
 
+/**
+ * 환불 요청
+ */
+data class RefundOrderItemsResult(
+    val orderId: Long,
+    val refundAmount: Long,
+    val refundedItemIds: List<Long>,
+    val orderStatus: OrderStatus,
+)
+
 data class OrderItemDetailResult(
     val itemId: Long,
     val skuId: Long,

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/application/usecase/MarkRefundCompletedUseCase.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/application/usecase/MarkRefundCompletedUseCase.kt
@@ -1,0 +1,47 @@
+package com.koosco.orderservice.application.usecase
+
+import com.koosco.common.core.annotation.UseCase
+import com.koosco.common.core.exception.NotFoundException
+import com.koosco.common.core.messaging.MessageContext
+import com.koosco.orderservice.application.command.MarkRefundCompletedCommand
+import com.koosco.orderservice.application.port.OrderRepository
+import com.koosco.orderservice.application.port.OrderStatusHistoryRepository
+import com.koosco.orderservice.common.error.OrderErrorCode
+import com.koosco.orderservice.domain.entity.OrderStatusHistory
+import org.slf4j.LoggerFactory
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class MarkRefundCompletedUseCase(
+    private val orderRepository: OrderRepository,
+    private val orderStatusHistoryRepository: OrderStatusHistoryRepository,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    fun execute(command: MarkRefundCompletedCommand, context: MessageContext) {
+        val order = orderRepository.findById(command.orderId)
+            ?: throw NotFoundException(OrderErrorCode.ORDER_NOT_FOUND)
+
+        val previousStatus = order.status
+
+        logger.info(
+            "Refund completed for order: orderId=${order.id}, " +
+                "canceledAmount=${command.canceledAmount}, " +
+                "isFullyCanceled=${command.isFullyCanceled}, " +
+                "currentStatus=$previousStatus",
+        )
+
+        orderStatusHistoryRepository.save(
+            OrderStatusHistory.create(
+                orderId = order.id!!,
+                fromStatus = previousStatus,
+                toStatus = order.status,
+                reason = "결제 취소 완료: canceledAmount=${command.canceledAmount}, " +
+                    "isFullyCanceled=${command.isFullyCanceled}",
+            ),
+        )
+
+        orderRepository.save(order)
+    }
+}

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/application/usecase/RefundOrderItemsUseCase.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/application/usecase/RefundOrderItemsUseCase.kt
@@ -1,0 +1,60 @@
+package com.koosco.orderservice.application.usecase
+
+import com.koosco.common.core.annotation.UseCase
+import com.koosco.common.core.exception.NotFoundException
+import com.koosco.orderservice.application.command.RefundOrderItemsCommand
+import com.koosco.orderservice.application.port.IntegrationEventProducer
+import com.koosco.orderservice.application.port.OrderRepository
+import com.koosco.orderservice.application.port.OrderStatusHistoryRepository
+import com.koosco.orderservice.application.result.RefundOrderItemsResult
+import com.koosco.orderservice.common.error.OrderErrorCode
+import com.koosco.orderservice.contract.outbound.order.OrderRefundRequestedEvent
+import com.koosco.orderservice.domain.entity.OrderStatusHistory
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@UseCase
+class RefundOrderItemsUseCase(
+    private val orderRepository: OrderRepository,
+    private val orderStatusHistoryRepository: OrderStatusHistoryRepository,
+    private val integrationEventProducer: IntegrationEventProducer,
+) {
+
+    @Transactional
+    fun execute(command: RefundOrderItemsCommand): RefundOrderItemsResult {
+        val order = orderRepository.findById(command.orderId)
+            ?: throw NotFoundException(OrderErrorCode.ORDER_NOT_FOUND)
+
+        val previousStatus = order.status
+        val refundAmount = order.refundAll(command.itemIds)
+
+        orderRepository.save(order)
+
+        orderStatusHistoryRepository.save(
+            OrderStatusHistory.create(
+                orderId = order.id!!,
+                fromStatus = previousStatus,
+                toStatus = order.status,
+                reason = "환불 요청: itemIds=${command.itemIds}",
+            ),
+        )
+
+        integrationEventProducer.publish(
+            OrderRefundRequestedEvent(
+                orderId = order.id!!,
+                userId = order.userId,
+                refundAmount = refundAmount.amount,
+                refundedItemIds = command.itemIds,
+                correlationId = order.id.toString(),
+                causationId = UUID.randomUUID().toString(),
+            ),
+        )
+
+        return RefundOrderItemsResult(
+            orderId = order.id!!,
+            refundAmount = refundAmount.amount,
+            refundedItemIds = command.itemIds,
+            orderStatus = order.status,
+        )
+    }
+}

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/contract/inbound/payment/PaymentCanceledEvent.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/contract/inbound/payment/PaymentCanceledEvent.kt
@@ -1,0 +1,13 @@
+package com.koosco.orderservice.contract.inbound.payment
+
+data class PaymentCanceledEvent(
+    val paymentId: String,
+    val orderId: Long,
+    val pgTransactionId: String?,
+    val canceledAmount: Long,
+    val totalCanceledAmount: Long,
+    val remainingAmount: Long,
+    val isFullyCanceled: Boolean,
+    val currency: String = "KRW",
+    val canceledAt: Long,
+)

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/contract/outbound/order/OrderRefundRequestedEvent.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/contract/outbound/order/OrderRefundRequestedEvent.kt
@@ -1,0 +1,14 @@
+package com.koosco.orderservice.contract.outbound.order
+
+import com.koosco.orderservice.contract.OrderIntegrationEvent
+
+data class OrderRefundRequestedEvent(
+    override val orderId: Long,
+    val userId: Long,
+    val refundAmount: Long,
+    val refundedItemIds: List<Long>,
+    val correlationId: String,
+    val causationId: String? = null,
+) : OrderIntegrationEvent {
+    override fun getEventType(): String = "order.refund.requested"
+}

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/domain/entity/OrderEventIdempotency.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/domain/entity/OrderEventIdempotency.kt
@@ -54,6 +54,7 @@ class OrderEventIdempotency(
             const val CANCEL_BY_PAYMENT_FAILURE = "CANCEL_BY_PAYMENT_FAILURE"
             const val MARK_FAILED_BY_STOCK_RESERVATION = "MARK_FAILED_BY_STOCK_RESERVATION"
             const val CANCEL_BY_STOCK_CONFIRM_FAILURE = "CANCEL_BY_STOCK_CONFIRM_FAILURE"
+            const val MARK_REFUND_COMPLETED = "MARK_REFUND_COMPLETED"
         }
 
         fun create(messageId: String, action: String, aggregateId: String): OrderEventIdempotency =

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/infra/messaging/kafka/consumer/KafkaPaymentCanceledConsumer.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/infra/messaging/kafka/consumer/KafkaPaymentCanceledConsumer.kt
@@ -1,0 +1,91 @@
+package com.koosco.orderservice.infra.messaging.kafka.consumer
+
+import com.koosco.common.core.event.CloudEvent
+import com.koosco.common.core.messaging.MessageContext
+import com.koosco.common.core.util.JsonUtils.objectMapper
+import com.koosco.orderservice.application.command.MarkRefundCompletedCommand
+import com.koosco.orderservice.application.usecase.MarkRefundCompletedUseCase
+import com.koosco.orderservice.contract.inbound.payment.PaymentCanceledEvent
+import com.koosco.orderservice.domain.entity.OrderEventIdempotency.Companion.Actions
+import com.koosco.orderservice.infra.idempotency.IdempotencyChecker
+import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+import org.springframework.validation.annotation.Validated
+
+@Component
+@Validated
+class KafkaPaymentCanceledConsumer(
+    private val markRefundCompletedUseCase: MarkRefundCompletedUseCase,
+    private val idempotencyChecker: IdempotencyChecker,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @KafkaListener(
+        topics = ["\${order.topic.mappings.payment.canceled}"],
+        groupId = "\${spring.kafka.consumer.group-id}",
+    )
+    fun onPaymentCanceled(@Valid event: CloudEvent<*>, ack: Acknowledgment) {
+        val payload = event.data
+            ?: run {
+                logger.error("PaymentCanceledEvent data is null: eventId=${event.id}")
+                ack.acknowledge()
+                return
+            }
+
+        val paymentCanceled = try {
+            objectMapper.convertValue(payload, PaymentCanceledEvent::class.java)
+        } catch (e: Exception) {
+            logger.error("Failed to deserialize PaymentCanceledEvent: eventId=${event.id}", e)
+            ack.acknowledge()
+            return
+        }
+
+        if (idempotencyChecker.isAlreadyProcessed(event.id, Actions.MARK_REFUND_COMPLETED)) {
+            logger.info("Event already processed: eventId=${event.id}, orderId=${paymentCanceled.orderId}")
+            ack.acknowledge()
+            return
+        }
+
+        logger.info(
+            "Received PaymentCanceledEvent: eventId=${event.id}, orderId=${paymentCanceled.orderId}, " +
+                "canceledAmount=${paymentCanceled.canceledAmount}",
+        )
+
+        val context = MessageContext(
+            correlationId = paymentCanceled.orderId.toString(),
+            causationId = event.id,
+        )
+
+        try {
+            markRefundCompletedUseCase.execute(
+                MarkRefundCompletedCommand(
+                    orderId = paymentCanceled.orderId,
+                    canceledAmount = paymentCanceled.canceledAmount,
+                    isFullyCanceled = paymentCanceled.isFullyCanceled,
+                ),
+                context,
+            )
+
+            idempotencyChecker.recordProcessed(
+                messageId = event.id,
+                action = Actions.MARK_REFUND_COMPLETED,
+                aggregateId = paymentCanceled.orderId.toString(),
+            )
+
+            ack.acknowledge()
+
+            logger.info(
+                "Successfully processed PaymentCanceled: eventId=${event.id}, orderId=${paymentCanceled.orderId}",
+            )
+        } catch (e: Exception) {
+            logger.error(
+                "Failed to process PaymentCanceledEvent: eventId=${event.id}, orderId=${paymentCanceled.orderId}",
+                e,
+            )
+            throw e
+        }
+    }
+}

--- a/services/order-service/src/main/resources/application.yaml
+++ b/services/order-service/src/main/resources/application.yaml
@@ -75,6 +75,7 @@ order:
         placed: koosco.commerce.order.placed
         confirmed: koosco.commerce.order.confirmed
         cancelled: koosco.commerce.order.cancelled
+        "refund.requested": koosco.commerce.order.refund.requested
       stock:
         reserved: koosco.commerce.stock.reserved
         "reservation.failed": koosco.commerce.stock.reservation.failed
@@ -85,6 +86,7 @@ order:
         created: koosco.commerce.payment.created
         completed: koosco.commerce.payment.completed
         failed: koosco.commerce.payment.failed
+        canceled: koosco.commerce.payment.canceled
 
 common:
   openapi:

--- a/services/payment-service/src/main/kotlin/com/koosco/paymentservice/application/command/CancelPaymentByOrderCommand.kt
+++ b/services/payment-service/src/main/kotlin/com/koosco/paymentservice/application/command/CancelPaymentByOrderCommand.kt
@@ -1,0 +1,3 @@
+package com.koosco.paymentservice.application.command
+
+data class CancelPaymentByOrderCommand(val orderId: Long, val cancelAmount: Long)

--- a/services/payment-service/src/main/kotlin/com/koosco/paymentservice/application/usecase/CancelPaymentByOrderUseCase.kt
+++ b/services/payment-service/src/main/kotlin/com/koosco/paymentservice/application/usecase/CancelPaymentByOrderUseCase.kt
@@ -1,0 +1,27 @@
+package com.koosco.paymentservice.application.usecase
+
+import com.koosco.common.core.annotation.UseCase
+import com.koosco.common.core.exception.NotFoundException
+import com.koosco.paymentservice.application.command.CancelPaymentByOrderCommand
+import com.koosco.paymentservice.application.command.CancelPaymentCommand
+import com.koosco.paymentservice.application.port.PaymentRepository
+import com.koosco.paymentservice.common.PaymentErrorCode
+
+@UseCase
+class CancelPaymentByOrderUseCase(
+    private val paymentRepository: PaymentRepository,
+    private val cancelPaymentUseCase: CancelPaymentUseCase,
+) {
+
+    fun execute(command: CancelPaymentByOrderCommand) {
+        val payment = paymentRepository.findByOrderId(command.orderId)
+            ?: throw NotFoundException(PaymentErrorCode.PAYMENT_NOT_FOUND)
+
+        cancelPaymentUseCase.execute(
+            CancelPaymentCommand(
+                paymentId = payment.paymentId,
+                cancelAmount = command.cancelAmount,
+            ),
+        )
+    }
+}

--- a/services/payment-service/src/main/kotlin/com/koosco/paymentservice/contract/inbound/order/OrderRefundRequestedEvent.kt
+++ b/services/payment-service/src/main/kotlin/com/koosco/paymentservice/contract/inbound/order/OrderRefundRequestedEvent.kt
@@ -1,0 +1,10 @@
+package com.koosco.paymentservice.contract.inbound.order
+
+data class OrderRefundRequestedEvent(
+    val orderId: Long,
+    val userId: Long,
+    val refundAmount: Long,
+    val refundedItemIds: List<Long>,
+    val correlationId: String,
+    val causationId: String? = null,
+)

--- a/services/payment-service/src/main/kotlin/com/koosco/paymentservice/infra/messaging/kafka/consumer/KafkaOrderRefundRequestedConsumer.kt
+++ b/services/payment-service/src/main/kotlin/com/koosco/paymentservice/infra/messaging/kafka/consumer/KafkaOrderRefundRequestedConsumer.kt
@@ -1,0 +1,83 @@
+package com.koosco.paymentservice.infra.messaging.kafka.consumer
+
+import com.koosco.common.core.event.CloudEvent
+import com.koosco.common.core.util.JsonUtils.objectMapper
+import com.koosco.paymentservice.application.command.CancelPaymentByOrderCommand
+import com.koosco.paymentservice.application.usecase.CancelPaymentByOrderUseCase
+import com.koosco.paymentservice.contract.inbound.order.OrderRefundRequestedEvent
+import com.koosco.paymentservice.domain.entity.PaymentIdempotency
+import com.koosco.paymentservice.infra.idempotency.IdempotencyChecker
+import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+import org.springframework.validation.annotation.Validated
+
+@Component
+@Validated
+class KafkaOrderRefundRequestedConsumer(
+    private val cancelPaymentByOrderUseCase: CancelPaymentByOrderUseCase,
+    private val idempotencyChecker: IdempotencyChecker,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @KafkaListener(
+        topics = ["\${payment.topic.mappings.order.refund.requested}"],
+        groupId = "\${spring.kafka.consumer.group-id}",
+    )
+    fun onOrderRefundRequested(@Valid event: CloudEvent<*>, ack: Acknowledgment) {
+        val rawData = event.data
+            ?: run {
+                logger.error("OrderRefundRequestedEvent data is null: eventId=${event.id}")
+                ack.acknowledge()
+                return
+            }
+
+        val refundEvent = try {
+            objectMapper.convertValue(rawData, OrderRefundRequestedEvent::class.java)
+        } catch (e: Exception) {
+            logger.error("Failed to deserialize OrderRefundRequestedEvent: eventId=${event.id}", e)
+            ack.acknowledge()
+            return
+        }
+
+        logger.info(
+            "Received OrderRefundRequestedEvent: eventId=${event.id}, orderId=${refundEvent.orderId}",
+        )
+
+        if (idempotencyChecker.isAlreadyProcessed(event.id, PaymentIdempotency.Companion.Actions.CANCEL)) {
+            logger.info("Event already processed: eventId=${event.id}")
+            ack.acknowledge()
+            return
+        }
+
+        try {
+            cancelPaymentByOrderUseCase.execute(
+                CancelPaymentByOrderCommand(
+                    orderId = refundEvent.orderId,
+                    cancelAmount = refundEvent.refundAmount,
+                ),
+            )
+
+            idempotencyChecker.recordProcessed(
+                event.id,
+                PaymentIdempotency.Companion.Actions.CANCEL,
+                refundEvent.orderId.toString(),
+            )
+
+            ack.acknowledge()
+
+            logger.info(
+                "Successfully processed refund: eventId=${event.id}, orderId=${refundEvent.orderId}, " +
+                    "refundAmount=${refundEvent.refundAmount}",
+            )
+        } catch (e: Exception) {
+            logger.error(
+                "Failed to process OrderRefundRequestedEvent: eventId=${event.id}, orderId=${refundEvent.orderId}",
+                e,
+            )
+            throw e
+        }
+    }
+}

--- a/services/payment-service/src/main/resources/application.yaml
+++ b/services/payment-service/src/main/resources/application.yaml
@@ -68,9 +68,11 @@ payment:
       order.placed: koosco.commerce.order.placed
       order.confirmed: koosco.commerce.order.confirmed
       order.cancelled: koosco.commerce.order.cancelled
+      order.refund.requested: koosco.commerce.order.refund.requested
       payment.created: koosco.commerce.payment.created
       payment.completed: koosco.commerce.payment.completed
       payment.failed: koosco.commerce.payment.failed
+      payment.canceled: koosco.commerce.payment.canceled
 
 common:
   openapi:


### PR DESCRIPTION
## Summary
- order-service에서 환불 요청 시 `OrderRefundRequestedEvent`를 Kafka로 발행하여 payment-service가 결제 취소를 처리하도록 이벤트 기반 연동을 구현
- payment-service가 결제 취소 완료 후 발행하는 `PaymentCanceledEvent`를 order-service가 수신하여 환불 완료를 기록
- 양 서비스 모두 Outbox 패턴 + 멱등성 체크 패턴을 기존 컨벤션에 맞춰 적용

## Changes

### order-service
- `OrderRefundRequestedEvent` outbound 이벤트 계약 추가
- `RefundOrderItemsUseCase` 신규 생성 (환불 금액 계산 + 이벤트 발행)
- `RefundOrderItemsRequest/Response`, `RefundOrderItemsCommand/Result` DTO 추가
- `OrderController`에 `POST /api/orders/{orderId}/refund` 엔드포인트 추가
- `PaymentCanceledEvent` inbound 이벤트 계약 추가
- `KafkaPaymentCanceledConsumer` 추가 (결제 취소 완료 수신)
- `MarkRefundCompletedUseCase` 추가 (환불 완료 상태 이력 기록)
- `OrderEventIdempotency`에 `MARK_REFUND_COMPLETED` 액션 추가
- `application.yaml`에 `order.refund.requested`, `payment.canceled` 토픽 매핑 추가

### payment-service
- `OrderRefundRequestedEvent` inbound 이벤트 계약 추가
- `KafkaOrderRefundRequestedConsumer` 추가 (환불 요청 수신)
- `CancelPaymentByOrderUseCase` 추가 (orderId 기반 결제 취소 위임)
- `CancelPaymentByOrderCommand` 추가
- `application.yaml`에 `order.refund.requested`, `payment.canceled` 토픽 매핑 추가

## Event Flow
```
[User] POST /api/orders/{orderId}/refund
  → [order-service] RefundOrderItemsUseCase
    → Kafka: OrderRefundRequestedEvent
      → [payment-service] KafkaOrderRefundRequestedConsumer
        → CancelPaymentByOrderUseCase → CancelPaymentUseCase
          → Kafka: PaymentCanceledEvent
            → [order-service] KafkaPaymentCanceledConsumer
              → MarkRefundCompletedUseCase (상태 이력 기록)
```

## Test plan
- [ ] order-service compileKotlin 성공 확인
- [ ] payment-service compileKotlin 성공 확인
- [ ] spotlessApply 통과 확인
- [ ] CONFIRMED/PAID 상태 주문에 대해 환불 API 호출 시 OrderRefundRequestedEvent 발행 확인
- [ ] payment-service에서 이벤트 수신 후 결제 취소 처리 확인
- [ ] PaymentCanceledEvent 발행 후 order-service에서 이력 기록 확인
- [ ] 중복 이벤트 수신 시 멱등성 동작 확인

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)