### PR TITLE
feat: Circuit Breaker 패턴 도입 (Redis, PG API) (#49, #25)

### DIFF
--- a/services/inventory-service/build.gradle.kts
+++ b/services/inventory-service/build.gradle.kts
@@ -56,6 +56,10 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.apache.commons:commons-pool2")
 
+    // resilience4j
+    implementation("io.github.resilience4j:resilience4j-spring-boot3:2.2.0")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
+
     // kafka
     implementation("org.springframework.kafka:spring-kafka")
     testImplementation("org.springframework.kafka:spring-kafka-test")

--- a/services/inventory-service/src/main/kotlin/com/koosco/inventoryservice/infra/storage/CircuitBreakerInventoryStockQueryAdapter.kt
+++ b/services/inventory-service/src/main/kotlin/com/koosco/inventoryservice/infra/storage/CircuitBreakerInventoryStockQueryAdapter.kt
@@ -1,0 +1,58 @@
+package com.koosco.inventoryservice.infra.storage
+
+import com.koosco.inventoryservice.application.port.InventoryStockQueryPort
+import com.koosco.inventoryservice.infra.storage.secondary.JpaInventorySnapshotRepository
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.annotation.Primary
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+@Primary
+@Component
+class CircuitBreakerInventoryStockQueryAdapter(
+    @Qualifier("redisInventoryStockQueryAdapter")
+    private val redisQueryAdapter: InventoryStockQueryPort,
+    private val snapshotRepository: JpaInventorySnapshotRepository,
+) : InventoryStockQueryPort {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @CircuitBreaker(name = "redis-stock", fallbackMethod = "getStockFallback")
+    override fun getStock(skuId: String): InventoryStockQueryPort.StockView = redisQueryAdapter.getStock(skuId)
+
+    @CircuitBreaker(name = "redis-stock", fallbackMethod = "getStocksFallback")
+    override fun getStocks(skuIds: List<String>): List<InventoryStockQueryPort.StockView> =
+        redisQueryAdapter.getStocks(skuIds)
+
+    @Suppress("unused")
+    private fun getStockFallback(skuId: String, ex: Throwable): InventoryStockQueryPort.StockView {
+        logger.warn("Redis circuit breaker open for getStock, falling back to MariaDB snapshot. skuId={}", skuId, ex)
+        val snapshot = snapshotRepository.findByIdOrNull(skuId)
+            ?: throw IllegalArgumentException("Inventory snapshot not found. skuId=$skuId")
+        return InventoryStockQueryPort.StockView(
+            skuId = snapshot.skuId,
+            total = snapshot.total,
+            reserved = snapshot.reserved,
+            available = snapshot.total - snapshot.reserved,
+        )
+    }
+
+    @Suppress("unused")
+    private fun getStocksFallback(skuIds: List<String>, ex: Throwable): List<InventoryStockQueryPort.StockView> {
+        logger.warn(
+            "Redis circuit breaker open for getStocks, falling back to MariaDB snapshot. skuIds={}",
+            skuIds,
+            ex,
+        )
+        val snapshots = snapshotRepository.findAllById(skuIds)
+        return snapshots.map {
+            InventoryStockQueryPort.StockView(
+                skuId = it.skuId,
+                total = it.total,
+                reserved = it.reserved,
+                available = it.total - it.reserved,
+            )
+        }
+    }
+}

--- a/services/inventory-service/src/main/kotlin/com/koosco/inventoryservice/infra/storage/CircuitBreakerInventoryStockStoreAdapter.kt
+++ b/services/inventory-service/src/main/kotlin/com/koosco/inventoryservice/infra/storage/CircuitBreakerInventoryStockStoreAdapter.kt
@@ -1,0 +1,141 @@
+package com.koosco.inventoryservice.infra.storage
+
+import com.koosco.common.core.exception.NotFoundException
+import com.koosco.inventoryservice.application.port.InventoryRepositoryPort
+import com.koosco.inventoryservice.application.port.InventoryStockStorePort
+import com.koosco.inventoryservice.common.InventoryErrorCode
+import com.koosco.inventoryservice.domain.entity.Inventory
+import com.koosco.inventoryservice.domain.vo.Stock
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.annotation.Primary
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Primary
+@Component
+class CircuitBreakerInventoryStockStoreAdapter(
+    @Qualifier("redisInventoryStockAdapter")
+    private val redisStockAdapter: InventoryStockStorePort,
+    private val inventoryRepository: InventoryRepositoryPort,
+) : InventoryStockStorePort {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @CircuitBreaker(name = "redis-stock", fallbackMethod = "initializeFallback")
+    override fun initialize(skuId: String, initialQuantity: Int) = redisStockAdapter.initialize(skuId, initialQuantity)
+
+    @CircuitBreaker(name = "redis-stock", fallbackMethod = "addFallback")
+    override fun add(items: List<InventoryStockStorePort.AddItem>) = redisStockAdapter.add(items)
+
+    @CircuitBreaker(name = "redis-stock", fallbackMethod = "reserveFallback")
+    override fun reserve(orderId: Long, items: List<InventoryStockStorePort.ReserveItem>) =
+        redisStockAdapter.reserve(orderId, items)
+
+    @CircuitBreaker(name = "redis-stock", fallbackMethod = "confirmFallback")
+    override fun confirm(orderId: Long, items: List<InventoryStockStorePort.ConfirmItem>) =
+        redisStockAdapter.confirm(orderId, items)
+
+    @CircuitBreaker(name = "redis-stock", fallbackMethod = "cancelFallback")
+    override fun cancel(orderId: Long, items: List<InventoryStockStorePort.CancelItem>) =
+        redisStockAdapter.cancel(orderId, items)
+
+    @CircuitBreaker(name = "redis-stock", fallbackMethod = "decreaseFallback")
+    override fun decrease(items: List<InventoryStockStorePort.DecreaseItem>) = redisStockAdapter.decrease(items)
+
+    @CircuitBreaker(name = "redis-stock", fallbackMethod = "getOrderIdsFallback")
+    override fun getOrderIds(skuId: String): Set<Long> = redisStockAdapter.getOrderIds(skuId)
+
+    @Suppress("unused")
+    @Transactional
+    private fun initializeFallback(skuId: String, initialQuantity: Int, ex: Throwable) {
+        logger.warn("Redis circuit breaker open for initialize, falling back to MariaDB. skuId={}", skuId, ex)
+        val existing = inventoryRepository.findBySkuIdOrNull(skuId)
+        if (existing != null) {
+            throw IllegalStateException("Inventory already initialized. skuId=$skuId")
+        }
+        inventoryRepository.save(
+            Inventory(skuId = skuId, stock = Stock(total = initialQuantity, reserved = 0)),
+        )
+    }
+
+    @Suppress("unused")
+    @Transactional
+    private fun addFallback(items: List<InventoryStockStorePort.AddItem>, ex: Throwable) {
+        logger.warn("Redis circuit breaker open for add, falling back to MariaDB", ex)
+        val skuIds = items.map { it.skuId }
+        val inventories = inventoryRepository.findAllBySkuIdInWithLock(skuIds).associateBy { it.skuId }
+        items.forEach { item ->
+            val inventory = inventories[item.skuId]
+                ?: throw NotFoundException(InventoryErrorCode.INVENTORY_NOT_FOUND)
+            inventory.increase(item.quantity)
+            inventoryRepository.save(inventory)
+        }
+    }
+
+    @Suppress("unused")
+    @Transactional
+    private fun reserveFallback(orderId: Long, items: List<InventoryStockStorePort.ReserveItem>, ex: Throwable) {
+        logger.warn("Redis circuit breaker open for reserve, falling back to MariaDB. orderId={}", orderId, ex)
+        val skuIds = items.map { it.skuId }
+        val inventories = inventoryRepository.findAllBySkuIdInWithLock(skuIds).associateBy { it.skuId }
+        items.forEach { item ->
+            val inventory = inventories[item.skuId]
+                ?: throw NotFoundException(InventoryErrorCode.INVENTORY_NOT_FOUND)
+            inventory.reserve(item.quantity)
+            inventoryRepository.save(inventory)
+        }
+    }
+
+    @Suppress("unused")
+    @Transactional
+    private fun confirmFallback(orderId: Long, items: List<InventoryStockStorePort.ConfirmItem>, ex: Throwable) {
+        logger.warn("Redis circuit breaker open for confirm, falling back to MariaDB. orderId={}", orderId, ex)
+        val skuIds = items.map { it.skuId }
+        val inventories = inventoryRepository.findAllBySkuIdInWithLock(skuIds).associateBy { it.skuId }
+        items.forEach { item ->
+            val inventory = inventories[item.skuId]
+                ?: throw NotFoundException(InventoryErrorCode.INVENTORY_NOT_FOUND)
+            inventory.confirm(item.quantity)
+            inventoryRepository.save(inventory)
+        }
+    }
+
+    @Suppress("unused")
+    @Transactional
+    private fun cancelFallback(orderId: Long, items: List<InventoryStockStorePort.CancelItem>, ex: Throwable) {
+        logger.warn("Redis circuit breaker open for cancel, falling back to MariaDB. orderId={}", orderId, ex)
+        val skuIds = items.map { it.skuId }
+        val inventories = inventoryRepository.findAllBySkuIdInWithLock(skuIds).associateBy { it.skuId }
+        items.forEach { item ->
+            val inventory = inventories[item.skuId]
+                ?: throw NotFoundException(InventoryErrorCode.INVENTORY_NOT_FOUND)
+            inventory.cancelReservation(item.quantity)
+            inventoryRepository.save(inventory)
+        }
+    }
+
+    @Suppress("unused")
+    @Transactional
+    private fun decreaseFallback(items: List<InventoryStockStorePort.DecreaseItem>, ex: Throwable) {
+        logger.warn("Redis circuit breaker open for decrease, falling back to MariaDB", ex)
+        val skuIds = items.map { it.skuId }
+        val inventories = inventoryRepository.findAllBySkuIdInWithLock(skuIds).associateBy { it.skuId }
+        items.forEach { item ->
+            val inventory = inventories[item.skuId]
+                ?: throw NotFoundException(InventoryErrorCode.INVENTORY_NOT_FOUND)
+            inventory.decrease(item.quantity)
+            inventoryRepository.save(inventory)
+        }
+    }
+
+    @Suppress("unused")
+    private fun getOrderIdsFallback(skuId: String, ex: Throwable): Set<Long> {
+        logger.warn(
+            "Redis circuit breaker open for getOrderIds, returning empty set. skuId={}",
+            skuId,
+            ex,
+        )
+        return emptySet()
+    }
+}

--- a/services/inventory-service/src/main/resources/application.yaml
+++ b/services/inventory-service/src/main/resources/application.yaml
@@ -54,11 +54,22 @@ spring:
       max-lifetime: 1800000
       leak-detection-threshold: 60000
 
+resilience4j:
+  circuitbreaker:
+    instances:
+      redis-stock:
+        slidingWindowSize: 10
+        failureRateThreshold: 50
+        waitDurationInOpenState: 30s
+        permittedNumberOfCallsInHalfOpenState: 3
+        slidingWindowType: COUNT_BASED
+        registerHealthIndicator: true
+
 management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics,prometheus
+        include: health,info,metrics,prometheus,circuitbreakers
       base-path: /actuator
   endpoint:
     health:

--- a/services/payment-service/build.gradle.kts
+++ b/services/payment-service/build.gradle.kts
@@ -38,6 +38,10 @@ dependencies {
     implementation("org.springframework.kafka:spring-kafka")
     testImplementation("org.springframework.kafka:spring-kafka-test")
 
+    // resilience4j
+    implementation("io.github.resilience4j:resilience4j-spring-boot3:2.2.0")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
+
     // swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1")
 

--- a/services/payment-service/src/main/kotlin/com/koosco/paymentservice/infra/client/TossPaymentGateway.kt
+++ b/services/payment-service/src/main/kotlin/com/koosco/paymentservice/infra/client/TossPaymentGateway.kt
@@ -4,6 +4,7 @@ import com.koosco.paymentservice.application.command.PaymentApproveCommand
 import com.koosco.paymentservice.application.command.PaymentApproveResult
 import com.koosco.paymentservice.application.port.PaymentGateway
 import com.koosco.paymentservice.domain.vo.Money
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import java.util.UUID
@@ -12,6 +13,7 @@ import java.util.UUID
 class TossPaymentGateway : PaymentGateway {
     private val logger = LoggerFactory.getLogger(javaClass)
 
+    @CircuitBreaker(name = "pg-api", fallbackMethod = "approveFallback")
     override fun approve(command: PaymentApproveCommand): PaymentApproveResult {
         logger.info(
             "Approving payment: paymentId={}, orderId={}, amount={}",
@@ -28,6 +30,7 @@ class TossPaymentGateway : PaymentGateway {
         )
     }
 
+    @CircuitBreaker(name = "pg-api", fallbackMethod = "cancelFallback")
     override fun cancel(paymentId: UUID, pgTransactionId: String, amount: Money): PaymentApproveResult {
         logger.info(
             "Cancelling payment: paymentId={}, pgTransactionId={}, amount={}",
@@ -40,6 +43,41 @@ class TossPaymentGateway : PaymentGateway {
         return PaymentApproveResult(
             success = true,
             pgTransactionId = pgTransactionId,
+        )
+    }
+
+    @Suppress("unused")
+    private fun approveFallback(command: PaymentApproveCommand, ex: Throwable): PaymentApproveResult {
+        logger.error(
+            "PG API circuit breaker open for approve. paymentId={}, orderId={}",
+            command.paymentId,
+            command.orderId,
+            ex,
+        )
+        return PaymentApproveResult(
+            success = false,
+            pgTransactionId = null,
+            failureReason = "PG_SERVICE_UNAVAILABLE",
+        )
+    }
+
+    @Suppress("unused")
+    private fun cancelFallback(
+        paymentId: UUID,
+        pgTransactionId: String,
+        amount: Money,
+        ex: Throwable,
+    ): PaymentApproveResult {
+        logger.error(
+            "PG API circuit breaker open for cancel. paymentId={}, pgTransactionId={}",
+            paymentId,
+            pgTransactionId,
+            ex,
+        )
+        return PaymentApproveResult(
+            success = false,
+            pgTransactionId = pgTransactionId,
+            failureReason = "PG_SERVICE_UNAVAILABLE",
         )
     }
 }

--- a/services/payment-service/src/main/resources/application.yaml
+++ b/services/payment-service/src/main/resources/application.yaml
@@ -36,11 +36,22 @@ spring:
       max-lifetime: 1800000
       leak-detection-threshold: 60000
 
+resilience4j:
+  circuitbreaker:
+    instances:
+      pg-api:
+        slidingWindowSize: 10
+        failureRateThreshold: 50
+        waitDurationInOpenState: 60s
+        permittedNumberOfCallsInHalfOpenState: 2
+        slidingWindowType: COUNT_BASED
+        registerHealthIndicator: true
+
 management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics,prometheus
+        include: health,info,metrics,prometheus,circuitbreakers
       base-path: /actuator
   endpoint:
     health:


### PR DESCRIPTION
## Summary
- inventory-service: Redis 장애 시 MariaDB fallback Circuit Breaker 적용
- payment-service: Toss Payments API에 Circuit Breaker 적용
- Resilience4j 의존성 및 설정 추가
- Actuator 메트릭 노출

Closes #49
Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)