### PR TITLE
refactor: Idempotency Key를 HTTP Header로 이동 (#55)

### DIFF
--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/BrandController.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/BrandController.kt
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
@@ -54,8 +55,11 @@ class BrandController(
     )
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    fun createBrand(@Valid @RequestBody request: BrandCreateRequest): ApiResponse<BrandResponse> {
-        val result = createBrandUseCase.execute(request.toCommand())
+    fun createBrand(
+        @Valid @RequestBody request: BrandCreateRequest,
+        @RequestHeader("Idempotency-Key", required = false) idempotencyKey: String?,
+    ): ApiResponse<BrandResponse> {
+        val result = createBrandUseCase.execute(request.toCommand(), idempotencyKey)
         return ApiResponse.success(BrandResponse.from(result))
     }
 

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/CategoryController.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/CategoryController.kt
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -77,10 +78,13 @@ class CategoryController(
     )
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    fun createCategory(@Valid @RequestBody request: CategoryCreateRequest): ApiResponse<CategoryResponse> {
+    fun createCategory(
+        @Valid @RequestBody request: CategoryCreateRequest,
+        @RequestHeader("Idempotency-Key", required = false) idempotencyKey: String?,
+    ): ApiResponse<CategoryResponse> {
         val command = request.toCommand()
 
-        val categoryInfo = createCategoryUseCase.execute(command)
+        val categoryInfo = createCategoryUseCase.execute(command, idempotencyKey)
 
         return ApiResponse.Companion.success(CategoryResponse.Companion.from(categoryInfo))
     }
@@ -92,10 +96,13 @@ class CategoryController(
     )
     @PostMapping("/tree")
     @ResponseStatus(HttpStatus.CREATED)
-    fun createCategoryTree(@Valid @RequestBody request: CategoryTreeCreateRequest): ApiResponse<CategoryTreeResponse> {
+    fun createCategoryTree(
+        @Valid @RequestBody request: CategoryTreeCreateRequest,
+        @RequestHeader("Idempotency-Key", required = false) idempotencyKey: String?,
+    ): ApiResponse<CategoryTreeResponse> {
         val command = request.toCommand()
 
-        val categoryTreeInfo = createCategoryTreeUseCase.execute(command)
+        val categoryTreeInfo = createCategoryTreeUseCase.execute(command, idempotencyKey)
 
         return ApiResponse.Companion.success(CategoryTreeResponse.Companion.from(categoryTreeInfo))
     }

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/ProductController.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/ProductController.kt
@@ -35,6 +35,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -124,8 +125,11 @@ class ProductController(
     )
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    fun createProduct(@Valid @RequestBody request: ProductCreateRequest): ApiResponse<ProductDetailResponse> {
-        val productInfo = createProductUseCase.execute(request.toCommand())
+    fun createProduct(
+        @Valid @RequestBody request: ProductCreateRequest,
+        @RequestHeader("Idempotency-Key", required = false) idempotencyKey: String?,
+    ): ApiResponse<ProductDetailResponse> {
+        val productInfo = createProductUseCase.execute(request.toCommand(), idempotencyKey)
 
         return ApiResponse.Companion.success(ProductDetailResponse.Companion.from(productInfo))
     }

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/ReviewController.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/ReviewController.kt
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -43,8 +44,9 @@ class ReviewController(
     fun createReview(
         @AuthId userId: Long,
         @Valid @RequestBody request: CreateReviewRequest,
+        @RequestHeader("Idempotency-Key", required = false) idempotencyKey: String?,
     ): ApiResponse<ReviewResponse> {
-        val result = createReviewUseCase.execute(request.toCommand(userId))
+        val result = createReviewUseCase.execute(request.toCommand(userId), idempotencyKey)
         return ApiResponse.Companion.success(ReviewResponse.from(result))
     }
 

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/SnapController.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/SnapController.kt
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -40,8 +41,12 @@ class SnapController(
 
     @Operation(summary = "스냅 작성")
     @PostMapping
-    fun createSnap(@AuthId userId: Long, @Valid @RequestBody request: CreateSnapRequest): ApiResponse<SnapResponse> {
-        val result = createSnapUseCase.execute(request.toCommand(userId))
+    fun createSnap(
+        @AuthId userId: Long,
+        @Valid @RequestBody request: CreateSnapRequest,
+        @RequestHeader("Idempotency-Key", required = false) idempotencyKey: String?,
+    ): ApiResponse<SnapResponse> {
+        val result = createSnapUseCase.execute(request.toCommand(userId), idempotencyKey)
         return ApiResponse.Companion.success(SnapResponse.from(result))
     }
 

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/request/BrandRequests.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/request/BrandRequests.kt
@@ -8,12 +8,10 @@ data class BrandCreateRequest(
     @field:NotBlank(message = "Brand name is required")
     val name: String,
     val logoImageUrl: String?,
-    val idempotencyKey: String? = null,
 ) {
     fun toCommand(): CreateBrandCommand = CreateBrandCommand(
         name = name,
         logoImageUrl = logoImageUrl,
-        idempotencyKey = idempotencyKey,
     )
 }
 

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/request/CategoryRequests.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/request/CategoryRequests.kt
@@ -12,13 +12,11 @@ data class CategoryCreateRequest(
     val parentId: Long?,
     @field:Min(value = 0, message = "카테고리 순서는 0 이상이어야 합니다.")
     val ordering: Int = 0,
-    val idempotencyKey: String? = null,
 ) {
     fun toCommand(): CreateCategoryCommand = CreateCategoryCommand(
         name = name,
         parentId = parentId,
         ordering = ordering,
-        idempotencyKey = idempotencyKey,
     )
 }
 
@@ -29,12 +27,10 @@ data class CategoryTreeCreateRequest(
     val ordering: Int = 0,
     @field:Valid
     val children: List<CategoryTreeCreateRequest> = emptyList(),
-    val idempotencyKey: String? = null,
 ) {
     fun toCommand(): CreateCategoryTreeCommand = CreateCategoryTreeCommand(
         name = name,
         ordering = ordering,
         children = children.map { it.toCommand() },
-        idempotencyKey = idempotencyKey,
     )
 }

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/request/ProductRequests.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/request/ProductRequests.kt
@@ -33,8 +33,6 @@ data class ProductCreateRequest(
 
     @field:Valid
     val optionGroups: List<ProductOptionGroup> = emptyList(),
-
-    val idempotencyKey: String? = null,
 ) {
     data class ProductOptionGroup(
         @field:NotBlank(message = "Option group name is required")
@@ -73,7 +71,6 @@ data class ProductCreateRequest(
         thumbnailImageUrl = thumbnailImageUrl,
         brandId = brandId,
         optionGroups = optionGroups.map { it.toCommand() },
-        idempotencyKey = idempotencyKey,
     )
 }
 

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/request/ReviewRequests.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/request/ReviewRequests.kt
@@ -25,8 +25,6 @@ data class CreateReviewRequest(
     val rating: Int,
 
     val imageUrls: List<String> = emptyList(),
-
-    val idempotencyKey: String? = null,
 ) {
     fun toCommand(userId: Long): CreateReviewCommand = CreateReviewCommand(
         productId = productId,
@@ -36,7 +34,6 @@ data class CreateReviewRequest(
         content = content,
         rating = rating,
         imageUrls = imageUrls,
-        idempotencyKey = idempotencyKey,
     )
 }
 

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/request/SnapRequests.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/request/SnapRequests.kt
@@ -11,15 +11,12 @@ data class CreateSnapRequest(
     val caption: String? = null,
 
     val imageUrls: List<String> = emptyList(),
-
-    val idempotencyKey: String? = null,
 ) {
     fun toCommand(userId: Long): CreateSnapCommand = CreateSnapCommand(
         productId = productId,
         userId = userId,
         caption = caption,
         imageUrls = imageUrls,
-        idempotencyKey = idempotencyKey,
     )
 }
 

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/BrandCommands.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/BrandCommands.kt
@@ -1,6 +1,6 @@
 package com.koosco.catalogservice.application.command
 
-data class CreateBrandCommand(val name: String, val logoImageUrl: String?, val idempotencyKey: String? = null)
+data class CreateBrandCommand(val name: String, val logoImageUrl: String?)
 
 data class UpdateBrandCommand(val brandId: Long, val name: String?, val logoImageUrl: String?)
 

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/CategoryCommand.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/CategoryCommand.kt
@@ -2,16 +2,10 @@ package com.koosco.catalogservice.application.command
 
 data class GetCategoryListCommand(val parentId: Long?)
 
-data class CreateCategoryCommand(
-    val name: String,
-    val parentId: Long?,
-    val ordering: Int = 0,
-    val idempotencyKey: String? = null,
-)
+data class CreateCategoryCommand(val name: String, val parentId: Long?, val ordering: Int = 0)
 
 data class CreateCategoryTreeCommand(
     val name: String,
     val ordering: Int = 0,
     val children: List<CreateCategoryTreeCommand> = emptyList(),
-    val idempotencyKey: String? = null,
 )

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/ProductCommand.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/ProductCommand.kt
@@ -11,7 +11,6 @@ data class CreateProductCommand(
     val thumbnailImageUrl: String?,
     val brandId: Long?,
     val optionGroups: List<ProductOptionGroup>,
-    val idempotencyKey: String? = null,
 ) {
     data class ProductOptionGroup(val name: String, val ordering: Int = 0, val options: List<ProductOption>)
 

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/ReviewCommands.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/ReviewCommands.kt
@@ -8,7 +8,6 @@ data class CreateReviewCommand(
     val content: String,
     val rating: Int,
     val imageUrls: List<String> = emptyList(),
-    val idempotencyKey: String? = null,
 )
 
 data class UpdateReviewCommand(

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/SnapCommands.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/SnapCommands.kt
@@ -5,7 +5,6 @@ data class CreateSnapCommand(
     val userId: Long,
     val caption: String?,
     val imageUrls: List<String> = emptyList(),
-    val idempotencyKey: String? = null,
 )
 
 data class UpdateSnapCommand(val snapId: Long, val userId: Long, val caption: String?)

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/CreateBrandUseCase.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/CreateBrandUseCase.kt
@@ -18,10 +18,10 @@ class CreateBrandUseCase(
 ) {
 
     @Transactional
-    fun execute(command: CreateBrandCommand): BrandResult {
-        if (command.idempotencyKey != null) {
+    fun execute(command: CreateBrandCommand, idempotencyKey: String? = null): BrandResult {
+        if (idempotencyKey != null) {
             val existing = catalogIdempotencyRepository.findByIdempotencyKeyAndResourceType(
-                command.idempotencyKey,
+                idempotencyKey,
                 "BRAND",
             )
             if (existing != null) {
@@ -37,9 +37,9 @@ class CreateBrandUseCase(
         )
         val saved = brandRepository.save(brand)
 
-        if (command.idempotencyKey != null) {
+        if (idempotencyKey != null) {
             catalogIdempotencyRepository.save(
-                CatalogIdempotency.create(command.idempotencyKey, "BRAND", saved.id!!),
+                CatalogIdempotency.create(idempotencyKey, "BRAND", saved.id!!),
             )
         }
 

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/CreateCategoryTreeUseCase.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/CreateCategoryTreeUseCase.kt
@@ -20,10 +20,10 @@ class CreateCategoryTreeUseCase(
 
     @CacheEvict(cacheNames = ["categoryTree"], allEntries = true)
     @Transactional
-    fun execute(command: CreateCategoryTreeCommand): CategoryTreeInfo {
-        if (command.idempotencyKey != null) {
+    fun execute(command: CreateCategoryTreeCommand, idempotencyKey: String? = null): CategoryTreeInfo {
+        if (idempotencyKey != null) {
             val existing = catalogIdempotencyRepository.findByIdempotencyKeyAndResourceType(
-                command.idempotencyKey,
+                idempotencyKey,
                 "CATEGORY_TREE",
             )
             if (existing != null) {
@@ -37,9 +37,9 @@ class CreateCategoryTreeUseCase(
 
         categoryRepository.save(rootCategory)
 
-        if (command.idempotencyKey != null) {
+        if (idempotencyKey != null) {
             catalogIdempotencyRepository.save(
-                CatalogIdempotency.create(command.idempotencyKey, "CATEGORY_TREE", rootCategory.id!!),
+                CatalogIdempotency.create(idempotencyKey, "CATEGORY_TREE", rootCategory.id!!),
             )
         }
 

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/CreateCategoryUseCase.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/CreateCategoryUseCase.kt
@@ -21,10 +21,10 @@ class CreateCategoryUseCase(
 
     @CacheEvict(cacheNames = ["categoryTree"], allEntries = true)
     @Transactional
-    fun execute(command: CreateCategoryCommand): CategoryInfo {
-        if (command.idempotencyKey != null) {
+    fun execute(command: CreateCategoryCommand, idempotencyKey: String? = null): CategoryInfo {
+        if (idempotencyKey != null) {
             val existing = catalogIdempotencyRepository.findByIdempotencyKeyAndResourceType(
-                command.idempotencyKey,
+                idempotencyKey,
                 "CATEGORY",
             )
             if (existing != null) {
@@ -53,9 +53,9 @@ class CreateCategoryUseCase(
         )
         val savedCategory = categoryRepository.save(category)
 
-        if (command.idempotencyKey != null) {
+        if (idempotencyKey != null) {
             catalogIdempotencyRepository.save(
-                CatalogIdempotency.create(command.idempotencyKey, "CATEGORY", savedCategory.id!!),
+                CatalogIdempotency.create(idempotencyKey, "CATEGORY", savedCategory.id!!),
             )
         }
 

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/CreateProductUseCase.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/CreateProductUseCase.kt
@@ -32,10 +32,10 @@ class CreateProductUseCase(
     private val logger = LoggerFactory.getLogger(javaClass)
 
     @Transactional
-    fun execute(command: CreateProductCommand): ProductInfo {
-        if (command.idempotencyKey != null) {
+    fun execute(command: CreateProductCommand, idempotencyKey: String? = null): ProductInfo {
+        if (idempotencyKey != null) {
             val existing = catalogIdempotencyRepository.findByIdempotencyKeyAndResourceType(
-                command.idempotencyKey,
+                idempotencyKey,
                 "PRODUCT",
             )
             if (existing != null) {
@@ -106,9 +106,9 @@ class CreateProductUseCase(
             )
         }
 
-        if (command.idempotencyKey != null) {
+        if (idempotencyKey != null) {
             catalogIdempotencyRepository.save(
-                CatalogIdempotency.create(command.idempotencyKey, "PRODUCT", savedProduct.id!!),
+                CatalogIdempotency.create(idempotencyKey, "PRODUCT", savedProduct.id!!),
             )
         }
 

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/CreateReviewUseCase.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/CreateReviewUseCase.kt
@@ -18,10 +18,10 @@ class CreateReviewUseCase(
 ) {
 
     @Transactional
-    fun execute(command: CreateReviewCommand): ReviewResult {
-        if (command.idempotencyKey != null) {
+    fun execute(command: CreateReviewCommand, idempotencyKey: String? = null): ReviewResult {
+        if (idempotencyKey != null) {
             val existing = catalogIdempotencyRepository.findByIdempotencyKeyAndResourceType(
-                command.idempotencyKey,
+                idempotencyKey,
                 "REVIEW",
             )
             if (existing != null) {
@@ -46,9 +46,9 @@ class CreateReviewUseCase(
 
         val saved = reviewRepository.save(review)
 
-        if (command.idempotencyKey != null) {
+        if (idempotencyKey != null) {
             catalogIdempotencyRepository.save(
-                CatalogIdempotency.create(command.idempotencyKey, "REVIEW", saved.id!!),
+                CatalogIdempotency.create(idempotencyKey, "REVIEW", saved.id!!),
             )
         }
 

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/CreateSnapUseCase.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/CreateSnapUseCase.kt
@@ -18,10 +18,10 @@ class CreateSnapUseCase(
 ) {
 
     @Transactional
-    fun execute(command: CreateSnapCommand): SnapResult {
-        if (command.idempotencyKey != null) {
+    fun execute(command: CreateSnapCommand, idempotencyKey: String? = null): SnapResult {
+        if (idempotencyKey != null) {
             val existing = catalogIdempotencyRepository.findByIdempotencyKeyAndResourceType(
-                command.idempotencyKey,
+                idempotencyKey,
                 "SNAP",
             )
             if (existing != null) {
@@ -43,9 +43,9 @@ class CreateSnapUseCase(
 
         val saved = snapRepository.save(snap)
 
-        if (command.idempotencyKey != null) {
+        if (idempotencyKey != null) {
             catalogIdempotencyRepository.save(
-                CatalogIdempotency.create(command.idempotencyKey, "SNAP", saved.id!!),
+                CatalogIdempotency.create(idempotencyKey, "SNAP", saved.id!!),
             )
         }
 


### PR DESCRIPTION
## Summary
- 모든 생성 Request/Command DTO에서 idempotencyKey 필드 제거
- Controller에서 @RequestHeader("Idempotency-Key")로 수신
- UseCase 시그니처에 별도 파라미터로 전달
- 업계 관례(Stripe, Toss Payments)와 일치

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)