### PR TITLE
feat: catalog-service 재고 연동 Kafka Consumer 추가 (#36)

### DIFF
--- a/.claude/docs/service-event-matrix.md
+++ b/.claude/docs/service-event-matrix.md
@@ -30,7 +30,7 @@ Each service has its own CLAUDE.md with specific guidance:
 | order-service | PaymentCreated/Completed/Failed, StockReserved/ReservationFailed/Confirmed/ConfirmFailed | 상태 전이 + DB 멱등성 | 7개 Consumer |
 | inventory-service | OrderPlaced/Confirmed/Cancelled, ProductSkuCreated | 상태 전이 | 4개 Consumer |
 | payment-service | OrderPlaced | **DB 멱등성** | IdempotencyRepository 사용 |
-| catalog-service | - | - | Consumer 없음 (Producer only) |
+| catalog-service | StockDepleted/StockRestored | 상태 전이 (멱등) | 1개 Consumer (2 event types) |
 
 ## Event Flow Summary
 
@@ -44,7 +44,9 @@ inventory-service (Producer)
     ├── StockReserved → order-service
     ├── StockReservationFailed → order-service
     ├── StockConfirmed → order-service
-    └── StockConfirmFailed → order-service
+    ├── StockConfirmFailed → order-service
+    ├── StockDepleted → catalog-service
+    └── StockRestored → catalog-service
 
 payment-service (Producer)
     ├── PaymentCreated → order-service

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/port/ProductRepository.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/port/ProductRepository.kt
@@ -11,5 +11,7 @@ interface ProductRepository {
 
     fun findByIdWithOptions(productId: Long): Product?
 
+    fun findBySkuId(skuId: String): Product?
+
     fun search(command: GetProductListCommand): Page<Product>
 }

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/UpdateProductStockStatusUseCase.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/UpdateProductStockStatusUseCase.kt
@@ -1,0 +1,96 @@
+package com.koosco.catalogservice.application.usecase
+
+import com.koosco.catalogservice.application.port.ProductRepository
+import com.koosco.catalogservice.domain.enums.ProductStatus
+import com.koosco.common.core.annotation.UseCase
+import org.slf4j.LoggerFactory
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class UpdateProductStockStatusUseCase(private val productRepository: ProductRepository) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * 재고 소진 시 상품 상태를 OUT_OF_STOCK으로 변경
+     * 이미 OUT_OF_STOCK이면 무시 (멱등성 보장)
+     */
+    @CacheEvict(cacheNames = ["productDetail"], allEntries = true)
+    @Transactional
+    fun markOutOfStock(skuId: String) {
+        val product = productRepository.findBySkuId(skuId)
+        if (product == null) {
+            logger.warn("Product not found for skuId={}. Ignoring stock depleted event.", skuId)
+            return
+        }
+
+        if (product.status == ProductStatus.OUT_OF_STOCK) {
+            logger.info(
+                "Product already OUT_OF_STOCK. productId={}, skuId={}",
+                product.id,
+                skuId,
+            )
+            return
+        }
+
+        if (!product.status.canTransitionTo(ProductStatus.OUT_OF_STOCK)) {
+            logger.warn(
+                "Cannot transition to OUT_OF_STOCK from {}. productId={}, skuId={}",
+                product.status,
+                product.id,
+                skuId,
+            )
+            return
+        }
+
+        product.changeStatus(ProductStatus.OUT_OF_STOCK)
+
+        logger.info(
+            "Product marked as OUT_OF_STOCK. productId={}, skuId={}",
+            product.id,
+            skuId,
+        )
+    }
+
+    /**
+     * 재고 복구 시 상품 상태를 ACTIVE로 변경
+     * 이미 ACTIVE이면 무시 (멱등성 보장)
+     */
+    @CacheEvict(cacheNames = ["productDetail"], allEntries = true)
+    @Transactional
+    fun markActive(skuId: String) {
+        val product = productRepository.findBySkuId(skuId)
+        if (product == null) {
+            logger.warn("Product not found for skuId={}. Ignoring stock restored event.", skuId)
+            return
+        }
+
+        if (product.status == ProductStatus.ACTIVE) {
+            logger.info(
+                "Product already ACTIVE. productId={}, skuId={}",
+                product.id,
+                skuId,
+            )
+            return
+        }
+
+        if (!product.status.canTransitionTo(ProductStatus.ACTIVE)) {
+            logger.warn(
+                "Cannot transition to ACTIVE from {}. productId={}, skuId={}",
+                product.status,
+                product.id,
+                skuId,
+            )
+            return
+        }
+
+        product.changeStatus(ProductStatus.ACTIVE)
+
+        logger.info(
+            "Product marked as ACTIVE. productId={}, skuId={}",
+            product.id,
+            skuId,
+        )
+    }
+}

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/common/config/KafkaConsumerConfig.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/common/config/KafkaConsumerConfig.kt
@@ -1,0 +1,96 @@
+package com.koosco.catalogservice.common.config
+
+import com.koosco.common.core.event.CloudEvent
+import com.koosco.common.core.exception.BaseException
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.annotation.EnableKafka
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.core.ConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.listener.ContainerProperties
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer
+import org.springframework.kafka.listener.DefaultErrorHandler
+import org.springframework.kafka.support.serializer.JsonDeserializer
+import org.springframework.util.backoff.ExponentialBackOff
+
+@EnableKafka
+@Configuration
+class KafkaConsumerConfig(
+    private val kafkaProperties: KafkaProperties,
+    private val kafkaTemplate: KafkaTemplate<String, CloudEvent<*>>,
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Bean
+    fun consumerFactory(): ConsumerFactory<String, CloudEvent<*>> {
+        val props = kafkaProperties.buildConsumerProperties(null).toMutableMap()
+
+        props[ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG] =
+            "org.apache.kafka.clients.consumer.CooperativeStickyAssignor"
+
+        val jsonDeserializer = JsonDeserializer(CloudEvent::class.java).apply {
+            addTrustedPackages("*")
+            setUseTypeHeaders(false)
+        }
+
+        return DefaultKafkaConsumerFactory(
+            props,
+            StringDeserializer(),
+            jsonDeserializer,
+        )
+    }
+
+    @Bean
+    fun deadLetterPublishingRecoverer(): DeadLetterPublishingRecoverer =
+        DeadLetterPublishingRecoverer(kafkaTemplate) { record, _ ->
+            TopicPartition("${record.topic()}.DLT", record.partition())
+        }
+
+    @Bean
+    fun kafkaErrorHandler(): DefaultErrorHandler {
+        val backOff = ExponentialBackOff().apply {
+            initialInterval = 1_000L
+            multiplier = 2.0
+            maxInterval = 10_000L
+            maxAttempts = MAX_RETRY_ATTEMPTS
+        }
+
+        return DefaultErrorHandler(deadLetterPublishingRecoverer(), backOff).apply {
+            addNotRetryableExceptions(BaseException::class.java)
+            setCommitRecovered(true)
+            setRetryListeners(
+                { record, ex, deliveryAttempt ->
+                    log.warn(
+                        "Retry attempt {} for topic={}, partition={}, offset={}: {}",
+                        deliveryAttempt,
+                        record.topic(),
+                        record.partition(),
+                        record.offset(),
+                        ex.message,
+                    )
+                },
+            )
+        }
+    }
+
+    @Bean
+    fun kafkaListenerContainerFactory(): ConcurrentKafkaListenerContainerFactory<String, CloudEvent<*>> {
+        val factory = ConcurrentKafkaListenerContainerFactory<String, CloudEvent<*>>()
+        factory.consumerFactory = consumerFactory()
+        factory.containerProperties.ackMode = ContainerProperties.AckMode.MANUAL_IMMEDIATE
+        factory.setCommonErrorHandler(kafkaErrorHandler())
+        return factory
+    }
+
+    companion object {
+        private const val MAX_RETRY_ATTEMPTS = 3
+    }
+}

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/contract/inbound/inventory/StockEvent.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/contract/inbound/inventory/StockEvent.kt
@@ -1,0 +1,23 @@
+package com.koosco.catalogservice.contract.inbound.inventory
+
+/**
+ * inventory-service에서 발행하는 재고 소진 이벤트
+ * 재고 확정 후 가용 재고가 0이 되었을 때 수신
+ */
+data class StockDepletedEvent(
+    val orderId: Long,
+    val skuId: String,
+    val correlationId: String,
+    val causationId: String?,
+)
+
+/**
+ * inventory-service에서 발행하는 재고 복구 이벤트
+ * 주문 취소로 가용 재고가 0에서 복구되었을 때 수신
+ */
+data class StockRestoredEvent(
+    val orderId: Long,
+    val skuId: String,
+    val correlationId: String,
+    val causationId: String?,
+)

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/messaging/kafka/consumer/KafkaStockEventConsumer.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/messaging/kafka/consumer/KafkaStockEventConsumer.kt
@@ -1,0 +1,93 @@
+package com.koosco.catalogservice.infra.messaging.kafka.consumer
+
+import com.koosco.catalogservice.application.usecase.UpdateProductStockStatusUseCase
+import com.koosco.catalogservice.contract.inbound.inventory.StockDepletedEvent
+import com.koosco.catalogservice.contract.inbound.inventory.StockRestoredEvent
+import com.koosco.common.core.event.CloudEvent
+import com.koosco.common.core.util.JsonUtils.objectMapper
+import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+import org.springframework.validation.annotation.Validated
+
+/**
+ * inventory-service에서 발행하는 재고 소진/복구 이벤트를 소비하여
+ * 상품 상태를 OUT_OF_STOCK 또는 ACTIVE로 변경
+ */
+@Component
+@Validated
+class KafkaStockEventConsumer(private val updateProductStockStatusUseCase: UpdateProductStockStatusUseCase) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @KafkaListener(
+        topics = ["\${catalog.topic.consumer.inventory.stock}"],
+        groupId = "\${spring.kafka.consumer.group-id}",
+    )
+    fun onStockEvent(@Valid event: CloudEvent<*>, ack: Acknowledgment) {
+        val payload = event.data
+            ?: run {
+                logger.error("Stock event data is null: eventId=${event.id}")
+                ack.acknowledge()
+                return
+            }
+
+        try {
+            when (event.type) {
+                EVENT_TYPE_STOCK_DEPLETED -> handleStockDepleted(event, payload)
+                EVENT_TYPE_STOCK_RESTORED -> handleStockRestored(event, payload)
+                else -> logger.debug("Ignoring unhandled event type: ${event.type}")
+            }
+        } catch (e: Exception) {
+            logger.error(
+                "Failed to process stock event: eventId=${event.id}, type=${event.type}",
+                e,
+            )
+            throw e
+        }
+
+        ack.acknowledge()
+    }
+
+    private fun handleStockDepleted(event: CloudEvent<*>, payload: Any) {
+        val stockDepleted = try {
+            objectMapper.convertValue(payload, StockDepletedEvent::class.java)
+        } catch (e: Exception) {
+            logger.error("Failed to deserialize StockDepletedEvent: eventId=${event.id}", e)
+            return // poison message -> skip
+        }
+
+        logger.info(
+            "Received StockDepletedEvent: eventId={}, skuId={}, orderId={}",
+            event.id,
+            stockDepleted.skuId,
+            stockDepleted.orderId,
+        )
+
+        updateProductStockStatusUseCase.markOutOfStock(stockDepleted.skuId)
+    }
+
+    private fun handleStockRestored(event: CloudEvent<*>, payload: Any) {
+        val stockRestored = try {
+            objectMapper.convertValue(payload, StockRestoredEvent::class.java)
+        } catch (e: Exception) {
+            logger.error("Failed to deserialize StockRestoredEvent: eventId=${event.id}", e)
+            return // poison message -> skip
+        }
+
+        logger.info(
+            "Received StockRestoredEvent: eventId={}, skuId={}, orderId={}",
+            event.id,
+            stockRestored.skuId,
+            stockRestored.orderId,
+        )
+
+        updateProductStockStatusUseCase.markActive(stockRestored.skuId)
+    }
+
+    companion object {
+        private const val EVENT_TYPE_STOCK_DEPLETED = "stock.depleted"
+        private const val EVENT_TYPE_STOCK_RESTORED = "stock.restored"
+    }
+}

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/persist/JpaProductRepository.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/persist/JpaProductRepository.kt
@@ -9,4 +9,7 @@ interface JpaProductRepository : JpaRepository<Product, Long> {
 
     @Query("SELECT DISTINCT p FROM Product p LEFT JOIN FETCH p.optionGroups WHERE p.id = :id")
     fun findByIdWithOptions(@Param("id") id: Long): Product?
+
+    @Query("SELECT p FROM Product p JOIN p.skus s WHERE s.skuId = :skuId")
+    fun findBySkuId(@Param("skuId") skuId: String): Product?
 }

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/persist/ProductRepositoryImpl.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/persist/ProductRepositoryImpl.kt
@@ -19,5 +19,7 @@ class ProductRepositoryImpl(
 
     override fun findByIdWithOptions(productId: Long): Product? = jpaProductRepository.findByIdWithOptions(productId)
 
+    override fun findBySkuId(skuId: String): Product? = jpaProductRepository.findBySkuId(skuId)
+
     override fun search(command: GetProductListCommand): Page<Product> = productQuery.search(command)
 }

--- a/services/catalog-service/src/main/resources/application.yaml
+++ b/services/catalog-service/src/main/resources/application.yaml
@@ -10,6 +10,11 @@ spring:
     bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     producer:
       bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+      group-id: catalog-service
+      auto-offset-reset: earliest
+      enable-auto-commit: false
   jpa:
     open-in-view: false
     hibernate:
@@ -64,6 +69,9 @@ catalog:
     mappings:
       "product.sku.created": koosco.commerce.product.default
       "product.status.changed": koosco.commerce.product.default
+    consumer:
+      inventory:
+        stock: koosco.commerce.inventory.stock
 
 common:
   openapi:

--- a/services/inventory-service/src/main/kotlin/com/koosco/inventoryservice/application/usecase/ConfirmStockUseCase.kt
+++ b/services/inventory-service/src/main/kotlin/com/koosco/inventoryservice/application/usecase/ConfirmStockUseCase.kt
@@ -6,9 +6,11 @@ import com.koosco.common.core.messaging.MessageContext
 import com.koosco.inventoryservice.application.command.ConfirmStockCommand
 import com.koosco.inventoryservice.application.port.IntegrationEventProducer
 import com.koosco.inventoryservice.application.port.InventoryLogPort
+import com.koosco.inventoryservice.application.port.InventoryStockQueryPort
 import com.koosco.inventoryservice.application.port.InventoryStockStorePort
 import com.koosco.inventoryservice.contract.outbound.inventory.StockConfirmFailedEvent
 import com.koosco.inventoryservice.contract.outbound.inventory.StockConfirmedEvent
+import com.koosco.inventoryservice.contract.outbound.inventory.StockDepletedEvent
 import com.koosco.inventoryservice.domain.enums.InventoryAction
 import com.koosco.inventoryservice.domain.enums.StockConfirmFailReason
 import com.koosco.inventoryservice.domain.exception.NotEnoughStockException
@@ -17,6 +19,7 @@ import org.slf4j.LoggerFactory
 @UseCase
 class ConfirmStockUseCase(
     private val inventoryStockStore: InventoryStockStorePort,
+    private val inventoryStockQuery: InventoryStockQueryPort,
     private val inventoryLogPort: InventoryLogPort,
     private val integrationEventProducer: IntegrationEventProducer,
 ) {
@@ -64,11 +67,44 @@ class ConfirmStockUseCase(
             ),
         )
 
+        // 재고 소진 여부 확인 후 StockDepleted 이벤트 발행
+        publishStockDepletedIfNeeded(command, context)
+
         logger.info(
             "Stock confirmed successfully. orderId={}, items={}",
             command.orderId,
             command.items.size,
         )
+    }
+
+    private fun publishStockDepletedIfNeeded(command: ConfirmStockCommand, context: MessageContext) {
+        command.items.forEach { item ->
+            try {
+                val stockView = inventoryStockQuery.getStock(item.skuId)
+                if (stockView.available <= 0) {
+                    integrationEventProducer.publish(
+                        StockDepletedEvent(
+                            orderId = command.orderId,
+                            skuId = item.skuId,
+                            correlationId = context.correlationId,
+                            causationId = context.causationId,
+                        ),
+                    )
+                    logger.info(
+                        "Stock depleted event published. skuId={}, orderId={}",
+                        item.skuId,
+                        command.orderId,
+                    )
+                }
+            } catch (e: Exception) {
+                logger.warn(
+                    "Failed to check stock depletion. skuId={}, orderId={}",
+                    item.skuId,
+                    command.orderId,
+                    e,
+                )
+            }
+        }
     }
 
     private fun publishFailed(command: ConfirmStockCommand, context: MessageContext, reason: StockConfirmFailReason) {

--- a/services/inventory-service/src/main/kotlin/com/koosco/inventoryservice/application/usecase/ReleaseStockUseCase.kt
+++ b/services/inventory-service/src/main/kotlin/com/koosco/inventoryservice/application/usecase/ReleaseStockUseCase.kt
@@ -3,20 +3,34 @@ package com.koosco.inventoryservice.application.usecase
 import com.koosco.common.core.annotation.UseCase
 import com.koosco.common.core.messaging.MessageContext
 import com.koosco.inventoryservice.application.command.CancelStockCommand
+import com.koosco.inventoryservice.application.port.IntegrationEventProducer
 import com.koosco.inventoryservice.application.port.InventoryLogPort
+import com.koosco.inventoryservice.application.port.InventoryStockQueryPort
 import com.koosco.inventoryservice.application.port.InventoryStockStorePort
+import com.koosco.inventoryservice.contract.outbound.inventory.StockRestoredEvent
 import com.koosco.inventoryservice.domain.enums.InventoryAction
 import org.slf4j.LoggerFactory
 
 @UseCase
 class ReleaseStockUseCase(
     private val inventoryStockStore: InventoryStockStorePort,
+    private val inventoryStockQuery: InventoryStockQueryPort,
     private val inventoryLogPort: InventoryLogPort,
+    private val integrationEventProducer: IntegrationEventProducer,
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
     fun execute(command: CancelStockCommand, context: MessageContext) {
+        // 취소 전 가용 재고 확인 (재고 복구 판단용)
+        val stockBeforeCancel = command.items.associate { item ->
+            item.skuId to try {
+                inventoryStockQuery.getStock(item.skuId).available
+            } catch (e: Exception) {
+                null
+            }
+        }
+
         inventoryStockStore.cancel(
             orderId = command.orderId,
             items = command.items.map {
@@ -38,8 +52,48 @@ class ReleaseStockUseCase(
             },
         )
 
+        // 재고 복구 여부 확인 후 StockRestored 이벤트 발행
+        publishStockRestoredIfNeeded(command, context, stockBeforeCancel)
+
         logger.info(
             "release stock for orderId=${command.orderId}, eventId=${context.correlationId}, causationId=${context.causationId}",
         )
+    }
+
+    private fun publishStockRestoredIfNeeded(
+        command: CancelStockCommand,
+        context: MessageContext,
+        stockBeforeCancel: Map<String, Int?>,
+    ) {
+        command.items.forEach { item ->
+            try {
+                val availableBefore = stockBeforeCancel[item.skuId] ?: return@forEach
+                if (availableBefore <= 0) {
+                    val stockAfter = inventoryStockQuery.getStock(item.skuId)
+                    if (stockAfter.available > 0) {
+                        integrationEventProducer.publish(
+                            StockRestoredEvent(
+                                orderId = command.orderId,
+                                skuId = item.skuId,
+                                correlationId = context.correlationId,
+                                causationId = context.causationId,
+                            ),
+                        )
+                        logger.info(
+                            "Stock restored event published. skuId={}, orderId={}",
+                            item.skuId,
+                            command.orderId,
+                        )
+                    }
+                }
+            } catch (e: Exception) {
+                logger.warn(
+                    "Failed to check stock restoration. skuId={}, orderId={}",
+                    item.skuId,
+                    command.orderId,
+                    e,
+                )
+            }
+        }
     }
 }

--- a/services/inventory-service/src/main/kotlin/com/koosco/inventoryservice/contract/outbound/inventory/StockDepletedEvent.kt
+++ b/services/inventory-service/src/main/kotlin/com/koosco/inventoryservice/contract/outbound/inventory/StockDepletedEvent.kt
@@ -1,0 +1,39 @@
+package com.koosco.inventoryservice.contract.outbound.inventory
+
+import com.koosco.inventoryservice.contract.InventoryIntegrationEvent
+
+/**
+ * 재고 소진 이벤트
+ * 재고 확정(confirm) 후 가용 재고가 0이 되었을 때 발행
+ * catalog-service가 소비하여 상품 상태를 OUT_OF_STOCK으로 변경
+ */
+data class StockDepletedEvent(
+    override val orderId: Long,
+    val skuId: String,
+    val correlationId: String,
+    val causationId: String?,
+) : InventoryIntegrationEvent {
+    override fun getEventType(): String = "stock.depleted"
+
+    override fun getPartitionKey(): String = skuId
+
+    override fun getSubject(): String = "inventory/$skuId"
+}
+
+/**
+ * 재고 복구 이벤트
+ * 재고 취소(cancel) 후 가용 재고가 0에서 복구되었을 때 발행
+ * catalog-service가 소비하여 상품 상태를 ACTIVE로 변경
+ */
+data class StockRestoredEvent(
+    override val orderId: Long,
+    val skuId: String,
+    val correlationId: String,
+    val causationId: String?,
+) : InventoryIntegrationEvent {
+    override fun getEventType(): String = "stock.restored"
+
+    override fun getPartitionKey(): String = skuId
+
+    override fun getSubject(): String = "inventory/$skuId"
+}

--- a/services/inventory-service/src/main/resources/application.yaml
+++ b/services/inventory-service/src/main/resources/application.yaml
@@ -87,6 +87,8 @@ inventory:
         confirmed: koosco.commerce.stock.confirmed
         "confirm.failed": koosco.commerce.stock.confirm.failed
         cancelled: koosco.commerce.stock.cancelled
+        depleted: koosco.commerce.inventory.stock
+        restored: koosco.commerce.inventory.stock
 
 jwt:
   secret: ${JWT_SECRET:mySecretKeyForJWTWhichShouldBeAtLeast256BitsLongToEnsureSecurityAndCompliance}


### PR DESCRIPTION
## Summary
- inventory-service: StockDepleted/StockRestored 이벤트 발행 로직 추가
- catalog-service: Kafka Consumer로 재고 이벤트 수신
- 상품 상태 OUT_OF_STOCK/ACTIVE 전이 구현
- 멱등성 보장 및 CloudEvent 파싱

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)