### PR TITLE
feat: 로그인 이벤트 발행 및 이력 추적 (#21)

### DIFF
--- a/services/user-service/src/main/kotlin/com/koosco/userservice/api/Requests.kt
+++ b/services/user-service/src/main/kotlin/com/koosco/userservice/api/Requests.kt
@@ -4,6 +4,7 @@ import com.koosco.common.core.annotation.NotBlankIfPresent
 import com.koosco.userservice.application.command.CreateUserCommand
 import com.koosco.userservice.application.command.LoginCommand
 import com.koosco.userservice.application.command.UpdateUserCommand
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.constraints.NotBlank
 
 data class RegisterRequest(
@@ -47,5 +48,15 @@ data class LoginRequest(
     @field:NotBlank(message = "비밀번호는 공백일 수 없습니다.")
     val password: String,
 ) {
-    fun toCommand(): LoginCommand = LoginCommand(email = email, password = password)
+    fun toCommand(request: HttpServletRequest): LoginCommand = LoginCommand(
+        email = email,
+        password = password,
+        ip = extractClientIp(request),
+        userAgent = request.getHeader("User-Agent"),
+    )
+
+    private fun extractClientIp(request: HttpServletRequest): String =
+        request.getHeader("X-Forwarded-For")?.split(",")?.firstOrNull()?.trim()
+            ?: request.getHeader("X-Real-IP")
+            ?: request.remoteAddr
 }

--- a/services/user-service/src/main/kotlin/com/koosco/userservice/api/controller/AuthController.kt
+++ b/services/user-service/src/main/kotlin/com/koosco/userservice/api/controller/AuthController.kt
@@ -26,8 +26,12 @@ class AuthController(
 
     @Operation(summary = "로그인", description = "이메일/비밀번호로 로그인하여 토큰을 발급합니다.")
     @PostMapping("/login")
-    fun login(@Valid @RequestBody request: LoginRequest, response: HttpServletResponse): ApiResponse<LoginResponse> {
-        val tokens = loginUseCase.execute(request.toCommand())
+    fun login(
+        @Valid @RequestBody request: LoginRequest,
+        httpRequest: HttpServletRequest,
+        response: HttpServletResponse,
+    ): ApiResponse<LoginResponse> {
+        val tokens = loginUseCase.execute(request.toCommand(httpRequest))
 
         response.addHeader("Authorization", tokens.accessToken)
 

--- a/services/user-service/src/main/kotlin/com/koosco/userservice/application/command/LoginCommand.kt
+++ b/services/user-service/src/main/kotlin/com/koosco/userservice/application/command/LoginCommand.kt
@@ -1,3 +1,3 @@
 package com.koosco.userservice.application.command
 
-data class LoginCommand(val email: String, val password: String)
+data class LoginCommand(val email: String, val password: String, val ip: String, val userAgent: String?)

--- a/services/user-service/src/main/kotlin/com/koosco/userservice/application/port/LoginHistoryRepository.kt
+++ b/services/user-service/src/main/kotlin/com/koosco/userservice/application/port/LoginHistoryRepository.kt
@@ -1,0 +1,7 @@
+package com.koosco.userservice.application.port
+
+import com.koosco.userservice.domain.entity.LoginHistory
+
+interface LoginHistoryRepository {
+    fun save(loginHistory: LoginHistory): LoginHistory
+}

--- a/services/user-service/src/main/kotlin/com/koosco/userservice/application/usecase/LoginUseCase.kt
+++ b/services/user-service/src/main/kotlin/com/koosco/userservice/application/usecase/LoginUseCase.kt
@@ -4,10 +4,12 @@ import com.koosco.common.core.annotation.UseCase
 import com.koosco.common.core.exception.NotFoundException
 import com.koosco.userservice.application.command.LoginCommand
 import com.koosco.userservice.application.dto.AuthTokenDto
+import com.koosco.userservice.application.port.LoginHistoryRepository
 import com.koosco.userservice.application.port.RefreshTokenStorePort
 import com.koosco.userservice.application.port.TokenGeneratorPort
 import com.koosco.userservice.application.port.UserRepository
 import com.koosco.userservice.common.MemberErrorCode
+import com.koosco.userservice.domain.entity.LoginHistory
 import com.koosco.userservice.domain.vo.Email
 import org.springframework.security.crypto.password.PasswordEncoder
 
@@ -17,16 +19,44 @@ class LoginUseCase(
     private val passwordEncoder: PasswordEncoder,
     private val tokenGeneratorPort: TokenGeneratorPort,
     private val refreshTokenStorePort: RefreshTokenStorePort,
+    private val loginHistoryRepository: LoginHistoryRepository,
 ) {
     fun execute(command: LoginCommand): AuthTokenDto {
         val member = userRepository.findByEmail(Email.of(command.email))
-            ?: throw NotFoundException(MemberErrorCode.INVALID_CREDENTIALS)
+
+        if (member == null) {
+            loginHistoryRepository.save(
+                LoginHistory.failure(
+                    userId = 0L,
+                    ip = command.ip,
+                    userAgent = command.userAgent,
+                    reason = "USER_NOT_FOUND",
+                ),
+            )
+            throw NotFoundException(MemberErrorCode.INVALID_CREDENTIALS)
+        }
 
         if (member.passwordHash == null ||
             !passwordEncoder.matches(command.password, member.passwordHash!!.value)
         ) {
+            loginHistoryRepository.save(
+                LoginHistory.failure(
+                    userId = member.id!!,
+                    ip = command.ip,
+                    userAgent = command.userAgent,
+                    reason = "INVALID_PASSWORD",
+                ),
+            )
             throw NotFoundException(MemberErrorCode.INVALID_CREDENTIALS)
         }
+
+        loginHistoryRepository.save(
+            LoginHistory.success(
+                userId = member.id!!,
+                ip = command.ip,
+                userAgent = command.userAgent,
+            ),
+        )
 
         val tokens = tokenGeneratorPort.generateTokens(
             userId = member.id!!,

--- a/services/user-service/src/main/kotlin/com/koosco/userservice/domain/entity/LoginHistory.kt
+++ b/services/user-service/src/main/kotlin/com/koosco/userservice/domain/entity/LoginHistory.kt
@@ -1,0 +1,52 @@
+package com.koosco.userservice.domain.entity
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "login_history",
+    indexes = [
+        Index(name = "idx_login_history_user_id", columnList = "user_id, login_at"),
+    ],
+)
+class LoginHistory(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: Long,
+
+    @Column(nullable = false)
+    val ip: String,
+
+    @Column(name = "user_agent", nullable = true, length = 512)
+    val userAgent: String?,
+
+    @Column(nullable = false)
+    val success: Boolean,
+
+    @Column(name = "failure_reason", nullable = true)
+    val failureReason: String? = null,
+
+    @Column(name = "login_at", nullable = false)
+    val loginAt: LocalDateTime = LocalDateTime.now(),
+) {
+    companion object {
+        fun success(userId: Long, ip: String, userAgent: String?): LoginHistory = LoginHistory(
+            userId = userId,
+            ip = ip,
+            userAgent = userAgent,
+            success = true,
+        )
+
+        fun failure(userId: Long, ip: String, userAgent: String?, reason: String): LoginHistory = LoginHistory(
+            userId = userId,
+            ip = ip,
+            userAgent = userAgent,
+            success = false,
+            failureReason = reason,
+        )
+    }
+}

--- a/services/user-service/src/main/kotlin/com/koosco/userservice/infra/persist/JpaLoginHistoryRepository.kt
+++ b/services/user-service/src/main/kotlin/com/koosco/userservice/infra/persist/JpaLoginHistoryRepository.kt
@@ -1,0 +1,11 @@
+package com.koosco.userservice.infra.persist
+
+import com.koosco.userservice.application.port.LoginHistoryRepository
+import com.koosco.userservice.domain.entity.LoginHistory
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface JpaLoginHistoryRepository :
+    JpaRepository<LoginHistory, Long>,
+    LoginHistoryRepository


### PR DESCRIPTION
## Summary
- LoginHistory 엔티티 생성 (userId, ip, userAgent, success, failureReason)
- LoginUseCase에서 로그인 성공/실패 시 이력 저장
- IP 추출 (X-Forwarded-For → X-Real-IP → remoteAddr fallback)
- CDC를 통한 이벤트 자동 발행 기반 구축

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)