### PR TITLE
feat: 상품 옵션 변경 시 SKU 동기화 (#37)

### DIFF
--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/request/ProductRequests.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/request/ProductRequests.kt
@@ -109,3 +109,35 @@ data class ChangeStatusRequest(
         status = status,
     )
 }
+
+/**
+ * Add Option Request
+ */
+data class AddOptionRequest(
+    @field:NotNull(message = "Option group ID is required")
+    val optionGroupId: Long,
+
+    @field:Valid
+    val options: List<OptionValueRequest>,
+) {
+    data class OptionValueRequest(
+        @field:NotBlank(message = "Option name is required")
+        val name: String,
+        @field:Min(value = 0, message = "Additional price must be non-negative")
+        val additionalPrice: Long = 0,
+        val ordering: Int = 0,
+    )
+
+    fun toCommand(productId: Long): com.koosco.catalogservice.application.command.AddProductOptionCommand =
+        com.koosco.catalogservice.application.command.AddProductOptionCommand(
+            productId = productId,
+            optionGroupId = optionGroupId,
+            options = options.map { option ->
+                com.koosco.catalogservice.application.command.AddProductOptionCommand.OptionValueSpec(
+                    name = option.name,
+                    additionalPrice = option.additionalPrice,
+                    ordering = option.ordering,
+                )
+            },
+        )
+}

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/ProductCommand.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/ProductCommand.kt
@@ -30,3 +30,9 @@ data class UpdateProductCommand(
 data class DeleteProductCommand(val productId: Long)
 
 data class ChangeProductStatusCommand(val productId: Long, val status: ProductStatus)
+
+data class AddProductOptionCommand(val productId: Long, val optionGroupId: Long, val options: List<OptionValueSpec>) {
+    data class OptionValueSpec(val name: String, val additionalPrice: Long = 0, val ordering: Int = 0)
+}
+
+data class RemoveProductOptionCommand(val productId: Long, val optionId: Long)

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/AddProductOptionUseCase.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/AddProductOptionUseCase.kt
@@ -1,0 +1,135 @@
+package com.koosco.catalogservice.application.usecase
+
+import com.koosco.catalogservice.application.command.AddProductOptionCommand
+import com.koosco.catalogservice.application.port.IntegrationEventProducer
+import com.koosco.catalogservice.application.port.ProductRepository
+import com.koosco.catalogservice.application.result.ProductInfo
+import com.koosco.catalogservice.common.error.CatalogErrorCode
+import com.koosco.catalogservice.contract.outbound.ProductSkuCreatedEvent
+import com.koosco.catalogservice.domain.entity.ProductOption
+import com.koosco.catalogservice.domain.entity.ProductSku
+import com.koosco.catalogservice.domain.vo.ProductOptions
+import com.koosco.common.core.annotation.UseCase
+import com.koosco.common.core.exception.NotFoundException
+import org.slf4j.LoggerFactory
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@UseCase
+class AddProductOptionUseCase(
+    private val productRepository: ProductRepository,
+    private val integrationEventProducer: IntegrationEventProducer,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    fun execute(command: AddProductOptionCommand): ProductInfo {
+        val product = productRepository.findByIdWithOptions(command.productId)
+            ?: throw NotFoundException(CatalogErrorCode.PRODUCT_NOT_FOUND)
+
+        val targetGroup = product.optionGroups.find { it.id == command.optionGroupId }
+            ?: throw NotFoundException(CatalogErrorCode.OPTION_NOT_FOUND)
+
+        // 기존 활성 SKU의 옵션 조합 수집
+        val existingCombinations = product.skus
+            .filter { it.isActive() }
+            .map { ProductOptions.fromJson(it.optionValues) }
+            .toSet()
+
+        // 새 옵션 값을 옵션 그룹에 추가
+        command.options.forEach { spec ->
+            val option = ProductOption(
+                name = spec.name,
+                additionalPrice = spec.additionalPrice,
+                ordering = spec.ordering,
+            )
+            targetGroup.addOption(option)
+        }
+
+        // 새로운 전체 조합 생성
+        val allCombinations = generateAllCombinations(product)
+
+        // diff: 새로 생성해야 할 조합
+        val newCombinations = allCombinations.filter { (options, _) ->
+            options !in existingCombinations
+        }
+
+        // 새 SKU 생성
+        val newSkus = newCombinations.map { (options, additionalPrice) ->
+            ProductSku.create(
+                product = product,
+                options = options.asMap(),
+                price = product.price + additionalPrice,
+            )
+        }
+
+        product.addSkus(newSkus)
+
+        val savedProduct = productRepository.save(product)
+
+        // 새 SKU에 대한 이벤트 발행
+        newSkus.forEach { sku ->
+            integrationEventProducer.publish(
+                ProductSkuCreatedEvent(
+                    skuId = sku.skuId,
+                    productId = savedProduct.id!!,
+                    productCode = product.productCode,
+                    price = sku.price,
+                    optionValues = sku.optionValues,
+                    initialQuantity = 0,
+                    createdAt = LocalDateTime.now(),
+                ),
+            )
+        }
+
+        logger.info(
+            "Product option added: productId=${savedProduct.id}, " +
+                "optionGroupId=${command.optionGroupId}, " +
+                "newSkuCount=${newSkus.size}",
+        )
+
+        return ProductInfo.from(savedProduct)
+    }
+
+    /**
+     * 현재 옵션 그룹 기준으로 모든 조합을 생성합니다.
+     * @return Pair<ProductOptions, additionalPrice>
+     */
+    private fun generateAllCombinations(
+        product: com.koosco.catalogservice.domain.entity.Product,
+    ): List<Pair<ProductOptions, Long>> {
+        if (product.optionGroups.isEmpty()) return emptyList()
+
+        val groups = product.optionGroups
+            .sortedBy { it.ordering }
+            .map { group ->
+                group.options
+                    .sortedBy { it.ordering }
+                    .map { option -> Triple(group.name, option.name, option.additionalPrice) }
+            }
+
+        return cartesianProduct(groups).map { combination ->
+            val optionsMap = combination.associate { (groupName, optionName, _) ->
+                groupName to optionName
+            }
+            val additionalPrice = combination.sumOf { (_, _, price) -> price }
+            ProductOptions.from(optionsMap) to additionalPrice
+        }
+    }
+
+    private fun <T> cartesianProduct(lists: List<List<T>>): List<List<T>> {
+        if (lists.isEmpty()) return listOf(emptyList())
+        if (lists.size == 1) return lists[0].map { listOf(it) }
+
+        val result = mutableListOf<List<T>>()
+        val rest = cartesianProduct(lists.drop(1))
+
+        for (item in lists[0]) {
+            for (r in rest) {
+                result.add(listOf(item) + r)
+            }
+        }
+
+        return result
+    }
+}

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/FindSkuUseCase.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/FindSkuUseCase.kt
@@ -19,10 +19,10 @@ class FindSkuUseCase(private val productRepository: ProductRepository) {
         // 입력받은 옵션을 VO로 변환
         val requestedOptions = ProductOptions.from(command.options)
 
-        // 일치하는 SKU 찾기 - 객체 비교
+        // 일치하는 활성 SKU 찾기 - 객체 비교
         val sku = product.skus.find { sku ->
-            val skuOptions = ProductOptions.fromJson(sku.optionValues)
-            skuOptions == requestedOptions
+            sku.isActive() &&
+                ProductOptions.fromJson(sku.optionValues) == requestedOptions
         } ?: throw IllegalArgumentException(
             "No SKU found for options: ${command.options}. " +
                 "Available SKUs: ${product.skus.map { productSku ->

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/RemoveProductOptionUseCase.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/RemoveProductOptionUseCase.kt
@@ -1,0 +1,78 @@
+package com.koosco.catalogservice.application.usecase
+
+import com.koosco.catalogservice.application.command.RemoveProductOptionCommand
+import com.koosco.catalogservice.application.port.IntegrationEventProducer
+import com.koosco.catalogservice.application.port.ProductRepository
+import com.koosco.catalogservice.application.result.ProductInfo
+import com.koosco.catalogservice.common.error.CatalogErrorCode
+import com.koosco.catalogservice.contract.outbound.ProductSkuDeactivatedEvent
+import com.koosco.catalogservice.domain.vo.ProductOptions
+import com.koosco.common.core.annotation.UseCase
+import com.koosco.common.core.exception.NotFoundException
+import org.slf4j.LoggerFactory
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@UseCase
+class RemoveProductOptionUseCase(
+    private val productRepository: ProductRepository,
+    private val integrationEventProducer: IntegrationEventProducer,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    fun execute(command: RemoveProductOptionCommand): ProductInfo {
+        val product = productRepository.findByIdWithOptions(command.productId)
+            ?: throw NotFoundException(CatalogErrorCode.PRODUCT_NOT_FOUND)
+
+        // 삭제 대상 옵션 찾기
+        val targetOption = product.optionGroups
+            .flatMap { group -> group.options.map { option -> group to option } }
+            .find { (_, option) -> option.id == command.optionId }
+            ?: throw NotFoundException(CatalogErrorCode.OPTION_NOT_FOUND)
+
+        val (targetGroup, removedOption) = targetOption
+        val groupName = targetGroup.name
+        val optionName = removedOption.name
+
+        // 해당 옵션을 포함하는 활성 SKU를 비활성화
+        val deactivatedSkus = product.skus.filter { sku ->
+            sku.isActive() && skuContainsOption(sku.optionValues, groupName, optionName)
+        }
+
+        deactivatedSkus.forEach { sku ->
+            sku.deactivate()
+        }
+
+        // 옵션 그룹에서 옵션 제거
+        targetGroup.options.remove(removedOption)
+
+        val savedProduct = productRepository.save(product)
+
+        // 비활성화된 SKU에 대한 이벤트 발행
+        deactivatedSkus.forEach { sku ->
+            integrationEventProducer.publish(
+                ProductSkuDeactivatedEvent(
+                    skuId = sku.skuId,
+                    productId = savedProduct.id!!,
+                    productCode = product.productCode,
+                    optionValues = sku.optionValues,
+                    deactivatedAt = LocalDateTime.now(),
+                ),
+            )
+        }
+
+        logger.info(
+            "Product option removed: productId=${savedProduct.id}, " +
+                "optionId=${command.optionId}, " +
+                "deactivatedSkuCount=${deactivatedSkus.size}",
+        )
+
+        return ProductInfo.from(savedProduct)
+    }
+
+    private fun skuContainsOption(optionValuesJson: String, groupName: String, optionName: String): Boolean {
+        val options = ProductOptions.fromJson(optionValuesJson).asMap()
+        return options[groupName] == optionName
+    }
+}

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/contract/outbound/ProductSkuDeactivatedEvent.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/contract/outbound/ProductSkuDeactivatedEvent.kt
@@ -1,0 +1,14 @@
+package com.koosco.catalogservice.contract.outbound
+
+import com.koosco.catalogservice.contract.ProductIntegrationEvent
+import java.time.LocalDateTime
+
+data class ProductSkuDeactivatedEvent(
+    override val skuId: String,
+    val productId: Long,
+    val productCode: String,
+    val optionValues: String,
+    val deactivatedAt: LocalDateTime,
+) : ProductIntegrationEvent {
+    override fun getEventType(): String = "product.sku.deactivated"
+}

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/domain/entity/ProductSku.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/domain/entity/ProductSku.kt
@@ -2,8 +2,11 @@ package com.koosco.catalogservice.domain.entity
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.koosco.catalogservice.domain.enums.SkuStatus
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -39,9 +42,19 @@ class ProductSku(
     @Column(name = "option_values", columnDefinition = "JSON")
     val optionValues: String,
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: SkuStatus = SkuStatus.ACTIVE,
+
     @Column(name = "created_at", nullable = false, updatable = false)
     val createdAt: LocalDateTime = LocalDateTime.now(),
 ) {
+
+    fun deactivate() {
+        this.status = SkuStatus.DEACTIVATED
+    }
+
+    fun isActive(): Boolean = status == SkuStatus.ACTIVE
 
     companion object {
         private val objectMapper: ObjectMapper = jacksonObjectMapper()

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/domain/enums/SkuStatus.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/domain/enums/SkuStatus.kt
@@ -1,0 +1,6 @@
+package com.koosco.catalogservice.domain.enums
+
+enum class SkuStatus {
+    ACTIVE,
+    DEACTIVATED,
+}


### PR DESCRIPTION
## Summary
- ProductSku에 status 필드 추가 (ACTIVE/DEACTIVATED)
- 옵션 추가 API: POST /api/products/{productId}/options
- 옵션 제거 API: DELETE /api/products/{productId}/options/{optionId}
- SKU diff 알고리즘으로 필요한 SKU만 생성/비활성화
- ProductSkuDeactivatedEvent 발행

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)