### PR TITLE
feat: Testcontainers 통합 테스트 인프라 구축 (#23)

### DIFF
--- a/common/common-core/build.gradle.kts
+++ b/common/common-core/build.gradle.kts
@@ -44,15 +44,17 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
-    // testcontainers (for KafkaContainerTestBase in testFixtures)
+    // testcontainers (for KafkaContainerTestBase, MariaDBContainerTestBase, etc. in testFixtures)
     testFixturesImplementation(platform("org.testcontainers:testcontainers-bom:1.19.7"))
     testFixturesImplementation("org.testcontainers:testcontainers")
     testFixturesImplementation("org.testcontainers:junit-jupiter")
     testFixturesImplementation("org.testcontainers:kafka")
+    testFixturesImplementation("org.testcontainers:mariadb")
     testFixturesImplementation("org.springframework.boot:spring-boot-testcontainers")
     testFixturesImplementation("org.springframework.kafka:spring-kafka")
     testFixturesImplementation("org.springframework.kafka:spring-kafka-test")
     testFixturesImplementation("org.springframework.boot:spring-boot-starter-test")
+    testFixturesImplementation("org.springframework.boot:spring-boot-starter-data-redis")
     testFixturesImplementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 }
 

--- a/common/common-core/src/testFixtures/kotlin/com/koosco/common/core/test/IntegrationTestBase.kt
+++ b/common/common-core/src/testFixtures/kotlin/com/koosco/common/core/test/IntegrationTestBase.kt
@@ -1,0 +1,167 @@
+package com.koosco.common.core.test
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.koosco.common.core.event.CloudEvent
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.common.serialization.StringSerializer
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.serializer.JsonDeserializer
+import org.springframework.kafka.support.serializer.JsonSerializer
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.KafkaContainer
+import org.testcontainers.containers.MariaDBContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+import java.time.Duration
+import java.util.Properties
+import java.util.UUID
+
+/**
+ * Unified base class for full integration tests combining MariaDB + Redis + Kafka containers.
+ *
+ * Provides:
+ * - Shared MariaDB container with JPA auto-DDL
+ * - Shared Redis container
+ * - Shared Kafka container with test utilities
+ * - Dynamic property configuration for all three
+ *
+ * Usage:
+ * ```kotlin
+ * @SpringBootTest
+ * @ActiveProfiles("test")
+ * class MyFullIntegrationTest : IntegrationTestBase() {
+ *     @Test
+ *     fun `should process order end-to-end`() {
+ *         // test with real MariaDB + Redis + Kafka
+ *     }
+ * }
+ * ```
+ */
+@Testcontainers
+abstract class IntegrationTestBase {
+
+    @Autowired
+    protected lateinit var objectMapper: ObjectMapper
+
+    companion object {
+        private const val MARIADB_IMAGE = "mariadb:10.11"
+        private const val REDIS_IMAGE = "redis:7.2-alpine"
+        private const val KAFKA_IMAGE = "confluentinc/cp-kafka:7.6.0"
+
+        @Container
+        @JvmStatic
+        val mariaDBContainer: MariaDBContainer<*> = MariaDBContainer(MARIADB_IMAGE)
+            .withDatabaseName("commerce-test")
+            .withUsername("test")
+            .withPassword("test")
+            .withReuse(true)
+
+        @Container
+        @JvmStatic
+        val redisContainer: GenericContainer<*> = GenericContainer(REDIS_IMAGE)
+            .withExposedPorts(6379)
+            .withReuse(true)
+
+        @Container
+        @JvmStatic
+        val kafkaContainer: KafkaContainer = KafkaContainer(DockerImageName.parse(KAFKA_IMAGE))
+            .withKraft()
+            .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "true")
+            .withEnv("KAFKA_NUM_PARTITIONS", "3")
+            .withReuse(true)
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun configureProperties(registry: DynamicPropertyRegistry) {
+            // MariaDB
+            registry.add("spring.datasource.url") { mariaDBContainer.jdbcUrl }
+            registry.add("spring.datasource.username") { mariaDBContainer.username }
+            registry.add("spring.datasource.password") { mariaDBContainer.password }
+            registry.add("spring.datasource.driver-class-name") { "org.mariadb.jdbc.Driver" }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "create-drop" }
+            registry.add("spring.jpa.properties.hibernate.dialect") {
+                "org.hibernate.dialect.MariaDBDialect"
+            }
+
+            // Redis
+            registry.add("spring.data.redis.host") { redisContainer.host }
+            registry.add("spring.data.redis.port") { redisContainer.getMappedPort(6379).toString() }
+
+            // Kafka (only set bootstrap-servers and minimal config;
+            // serializer/deserializer config is handled by each service's KafkaConfig or application.yaml)
+            registry.add("spring.kafka.bootstrap-servers") { kafkaContainer.bootstrapServers }
+            registry.add("spring.kafka.producer.bootstrap-servers") { kafkaContainer.bootstrapServers }
+            registry.add("spring.kafka.consumer.bootstrap-servers") { kafkaContainer.bootstrapServers }
+            registry.add("spring.kafka.consumer.auto-offset-reset") { "earliest" }
+            registry.add("spring.kafka.consumer.group-id") { "test-group-${UUID.randomUUID()}" }
+        }
+    }
+
+    /**
+     * Create a test KafkaConsumer for the given topic.
+     */
+    protected fun createTestConsumer(
+        topic: String,
+        groupId: String = "test-consumer-${UUID.randomUUID()}",
+    ): KafkaConsumer<String, CloudEvent<*>> {
+        val props = Properties().apply {
+            put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.bootstrapServers)
+            put(ConsumerConfig.GROUP_ID_CONFIG, groupId)
+            put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+            put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java)
+            put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer::class.java)
+            put(JsonDeserializer.TRUSTED_PACKAGES, "*")
+            put(JsonDeserializer.VALUE_DEFAULT_TYPE, CloudEvent::class.java.name)
+        }
+
+        return KafkaConsumer<String, CloudEvent<*>>(props).apply {
+            subscribe(listOf(topic))
+        }
+    }
+
+    /**
+     * Consume messages from a topic with timeout.
+     */
+    protected fun consumeMessages(
+        topic: String,
+        expectedCount: Int,
+        timeout: Duration = Duration.ofSeconds(10),
+    ): List<ConsumerRecord<String, CloudEvent<*>>> {
+        val consumer = createTestConsumer(topic)
+        val records = mutableListOf<ConsumerRecord<String, CloudEvent<*>>>()
+        val deadline = System.currentTimeMillis() + timeout.toMillis()
+
+        try {
+            while (records.size < expectedCount && System.currentTimeMillis() < deadline) {
+                val polled = consumer.poll(Duration.ofMillis(500))
+                records.addAll(polled)
+            }
+        } finally {
+            consumer.close()
+        }
+
+        return records
+    }
+
+    /**
+     * Create a test KafkaTemplate for sending messages.
+     */
+    protected fun createTestKafkaTemplate(): KafkaTemplate<String, CloudEvent<*>> {
+        val props = mapOf(
+            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to kafkaContainer.bootstrapServers,
+            ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java,
+            ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to JsonSerializer::class.java,
+        )
+        val factory = DefaultKafkaProducerFactory<String, CloudEvent<*>>(props)
+        return KafkaTemplate(factory)
+    }
+}

--- a/common/common-core/src/testFixtures/kotlin/com/koosco/common/core/test/MariaDBContainerTestBase.kt
+++ b/common/common-core/src/testFixtures/kotlin/com/koosco/common/core/test/MariaDBContainerTestBase.kt
@@ -1,0 +1,56 @@
+package com.koosco.common.core.test
+
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.MariaDBContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+
+/**
+ * Base class for MariaDB integration tests using Testcontainers.
+ *
+ * Provides:
+ * - Shared MariaDB container (started once per test class)
+ * - Dynamic property configuration for Spring DataSource
+ * - JPA ddl-auto set to create-drop for clean test schema
+ *
+ * Usage:
+ * ```kotlin
+ * @SpringBootTest
+ * @ActiveProfiles("test")
+ * class MyDatabaseTest : MariaDBContainerTestBase() {
+ *     @Test
+ *     fun `should save entity`() {
+ *         // test with real MariaDB
+ *     }
+ * }
+ * ```
+ */
+@Testcontainers
+abstract class MariaDBContainerTestBase {
+
+    companion object {
+        private const val MARIADB_IMAGE = "mariadb:10.11"
+
+        @Container
+        @JvmStatic
+        val mariaDBContainer: MariaDBContainer<*> = MariaDBContainer(MARIADB_IMAGE)
+            .withDatabaseName("commerce-test")
+            .withUsername("test")
+            .withPassword("test")
+            .withReuse(true)
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun mariaDBProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { mariaDBContainer.jdbcUrl }
+            registry.add("spring.datasource.username") { mariaDBContainer.username }
+            registry.add("spring.datasource.password") { mariaDBContainer.password }
+            registry.add("spring.datasource.driver-class-name") { "org.mariadb.jdbc.Driver" }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "create-drop" }
+            registry.add("spring.jpa.properties.hibernate.dialect") {
+                "org.hibernate.dialect.MariaDBDialect"
+            }
+        }
+    }
+}

--- a/common/common-core/src/testFixtures/kotlin/com/koosco/common/core/test/RedisContainerTestBase.kt
+++ b/common/common-core/src/testFixtures/kotlin/com/koosco/common/core/test/RedisContainerTestBase.kt
@@ -1,0 +1,47 @@
+package com.koosco.common.core.test
+
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+
+/**
+ * Base class for Redis integration tests using Testcontainers.
+ *
+ * Provides:
+ * - Shared Redis container (started once per test class)
+ * - Dynamic property configuration for Spring Data Redis
+ *
+ * Usage:
+ * ```kotlin
+ * @SpringBootTest
+ * @ActiveProfiles("test")
+ * class MyRedisTest : RedisContainerTestBase() {
+ *     @Test
+ *     fun `should store value in Redis`() {
+ *         // test with real Redis
+ *     }
+ * }
+ * ```
+ */
+@Testcontainers
+abstract class RedisContainerTestBase {
+
+    companion object {
+        private const val REDIS_IMAGE = "redis:7.2-alpine"
+
+        @Container
+        @JvmStatic
+        val redisContainer: GenericContainer<*> = GenericContainer(REDIS_IMAGE)
+            .withExposedPorts(6379)
+            .withReuse(true)
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun redisProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.data.redis.host") { redisContainer.host }
+            registry.add("spring.data.redis.port") { redisContainer.getMappedPort(6379).toString() }
+        }
+    }
+}

--- a/services/catalog-service/build.gradle.kts
+++ b/services/catalog-service/build.gradle.kts
@@ -71,6 +71,7 @@ dependencies {
     testImplementation("org.testcontainers:testcontainers")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:kafka")
+    testImplementation("org.testcontainers:mariadb")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
 
     // common-core test fixtures (KafkaContainerTestBase)

--- a/services/catalog-service/src/test/kotlin/com/koosco/catalogservice/integration/category/CategoryIntegrationTest.kt
+++ b/services/catalog-service/src/test/kotlin/com/koosco/catalogservice/integration/category/CategoryIntegrationTest.kt
@@ -1,0 +1,148 @@
+package com.koosco.catalogservice.integration.category
+
+import com.koosco.catalogservice.application.command.CreateCategoryCommand
+import com.koosco.catalogservice.application.command.CreateCategoryTreeCommand
+import com.koosco.catalogservice.application.command.GetCategoryListCommand
+import com.koosco.catalogservice.application.port.CategoryRepository
+import com.koosco.catalogservice.application.usecase.CreateCategoryTreeUseCase
+import com.koosco.catalogservice.application.usecase.CreateCategoryUseCase
+import com.koosco.catalogservice.application.usecase.GetCategoryListUseCase
+import com.koosco.catalogservice.application.usecase.GetCategoryTreeUseCase
+import com.koosco.common.core.test.IntegrationTestBase
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+/**
+ * Integration test for category creation and query using real MariaDB container.
+ *
+ * Verifies:
+ * - Root category creation and persistence
+ * - Child category creation under parent
+ * - Category tree creation (hierarchical)
+ * - Category list and tree query
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class CategoryIntegrationTest : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var createCategoryUseCase: CreateCategoryUseCase
+
+    @Autowired
+    private lateinit var createCategoryTreeUseCase: CreateCategoryTreeUseCase
+
+    @Autowired
+    private lateinit var getCategoryListUseCase: GetCategoryListUseCase
+
+    @Autowired
+    private lateinit var getCategoryTreeUseCase: GetCategoryTreeUseCase
+
+    @Autowired
+    private lateinit var categoryRepository: CategoryRepository
+
+    @Test
+    fun `should create root category and query it`() {
+        // given
+        val command = CreateCategoryCommand(
+            name = "Electronics",
+            parentId = null,
+            ordering = 1,
+        )
+
+        // when
+        val result = createCategoryUseCase.execute(command)
+
+        // then
+        assertNotNull(result.id)
+        assertEquals("Electronics", result.name)
+        assertEquals(0, result.depth)
+        assertNull(result.parentId)
+    }
+
+    @Test
+    fun `should create child category under parent`() {
+        // given
+        val parentResult = createCategoryUseCase.execute(
+            CreateCategoryCommand(name = "Fashion", parentId = null, ordering = 2),
+        )
+        val childCommand = CreateCategoryCommand(
+            name = "Shoes",
+            parentId = parentResult.id,
+            ordering = 1,
+        )
+
+        // when
+        val childResult = createCategoryUseCase.execute(childCommand)
+
+        // then
+        assertNotNull(childResult.id)
+        assertEquals("Shoes", childResult.name)
+        assertEquals(1, childResult.depth)
+        assertEquals(parentResult.id, childResult.parentId)
+    }
+
+    @Test
+    fun `should create category tree and query as tree structure`() {
+        // given
+        val treeCommand = CreateCategoryTreeCommand(
+            name = "Home & Living",
+            ordering = 3,
+            children = listOf(
+                CreateCategoryTreeCommand(
+                    name = "Furniture",
+                    ordering = 1,
+                    children = listOf(
+                        CreateCategoryTreeCommand(name = "Sofas", ordering = 1),
+                        CreateCategoryTreeCommand(name = "Tables", ordering = 2),
+                    ),
+                ),
+                CreateCategoryTreeCommand(
+                    name = "Kitchen",
+                    ordering = 2,
+                ),
+            ),
+        )
+
+        // when
+        val treeResult = createCategoryTreeUseCase.execute(treeCommand)
+
+        // then
+        assertEquals("Home & Living", treeResult.name)
+        assertEquals(2, treeResult.children.size)
+
+        val furniture = treeResult.children.find { it.name == "Furniture" }
+        assertNotNull(furniture)
+        assertEquals(2, furniture!!.children.size)
+        assertTrue(furniture.children.any { it.name == "Sofas" })
+        assertTrue(furniture.children.any { it.name == "Tables" })
+
+        val kitchen = treeResult.children.find { it.name == "Kitchen" }
+        assertNotNull(kitchen)
+        assertTrue(kitchen!!.children.isEmpty())
+    }
+
+    @Test
+    fun `should list root categories`() {
+        // given - create root categories
+        createCategoryUseCase.execute(
+            CreateCategoryCommand(name = "Sports", parentId = null, ordering = 10),
+        )
+        createCategoryUseCase.execute(
+            CreateCategoryCommand(name = "Books", parentId = null, ordering = 11),
+        )
+
+        // when
+        val rootCategories = getCategoryListUseCase.execute(GetCategoryListCommand(parentId = null))
+
+        // then
+        assertTrue(rootCategories.size >= 2)
+        assertTrue(rootCategories.any { it.name == "Sports" })
+        assertTrue(rootCategories.any { it.name == "Books" })
+    }
+}

--- a/services/inventory-service/build.gradle.kts
+++ b/services/inventory-service/build.gradle.kts
@@ -78,7 +78,11 @@ dependencies {
     testImplementation("org.testcontainers:testcontainers")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:kafka")
+    testImplementation("org.testcontainers:mariadb")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
+
+    // common-core test fixtures (IntegrationTestBase, MariaDBContainerTestBase, etc.)
+    testImplementation(testFixtures(project(":common:common-core")))
 }
 
 // Querydsl

--- a/services/inventory-service/src/test/kotlin/com/koosco/inventoryservice/integration/stock/StockIntegrationTest.kt
+++ b/services/inventory-service/src/test/kotlin/com/koosco/inventoryservice/integration/stock/StockIntegrationTest.kt
@@ -1,0 +1,63 @@
+package com.koosco.inventoryservice.integration.stock
+
+import com.koosco.common.core.test.IntegrationTestBase
+import com.koosco.inventoryservice.application.command.GetInventoryCommand
+import com.koosco.inventoryservice.application.command.InitStockCommand
+import com.koosco.inventoryservice.application.usecase.GetInventoryUseCase
+import com.koosco.inventoryservice.application.usecase.InitializeStockUseCase
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.util.UUID
+
+/**
+ * Integration test for stock initialization and query using real Redis + MariaDB containers.
+ *
+ * Verifies:
+ * - Stock initialization stores data in Redis correctly
+ * - Stock query returns accurate total/reserved/available values
+ * - Duplicate initialization is rejected with proper error
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class StockIntegrationTest : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var initializeStockUseCase: InitializeStockUseCase
+
+    @Autowired
+    private lateinit var getInventoryUseCase: GetInventoryUseCase
+
+    @Test
+    fun `should initialize stock and query it correctly`() {
+        // given
+        val skuId = "TEST-SKU-INIT-${UUID.randomUUID()}"
+        val initialQuantity = 100
+
+        // when
+        initializeStockUseCase.execute(InitStockCommand(skuId, initialQuantity))
+
+        // then
+        val result = getInventoryUseCase.execute(GetInventoryCommand(skuId))
+        assertEquals(skuId, result.skuId)
+        assertEquals(initialQuantity, result.totalStock)
+        assertEquals(0, result.reservedStock)
+        assertEquals(initialQuantity, result.availableStock)
+    }
+
+    @Test
+    fun `should reject duplicate stock initialization`() {
+        // given
+        val skuId = "TEST-SKU-DUP-${UUID.randomUUID()}"
+        val initialQuantity = 50
+        initializeStockUseCase.execute(InitStockCommand(skuId, initialQuantity))
+
+        // when & then
+        assertThrows(IllegalStateException::class.java) {
+            initializeStockUseCase.execute(InitStockCommand(skuId, initialQuantity))
+        }
+    }
+}

--- a/services/order-service/build.gradle.kts
+++ b/services/order-service/build.gradle.kts
@@ -56,7 +56,11 @@ dependencies {
     testImplementation("org.testcontainers:testcontainers")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:kafka")
+    testImplementation("org.testcontainers:mariadb")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
+
+    // common-core test fixtures (IntegrationTestBase, MariaDBContainerTestBase, etc.)
+    testImplementation(testFixtures(project(":common:common-core")))
 }
 
 spotless {

--- a/services/order-service/src/test/kotlin/com/koosco/orderservice/integration/order/CreateOrderIntegrationTest.kt
+++ b/services/order-service/src/test/kotlin/com/koosco/orderservice/integration/order/CreateOrderIntegrationTest.kt
@@ -1,0 +1,120 @@
+package com.koosco.orderservice.integration.order
+
+import com.koosco.common.core.test.IntegrationTestBase
+import com.koosco.orderservice.application.command.CreateOrderCommand
+import com.koosco.orderservice.application.usecase.CreateOrderUseCase
+import com.koosco.orderservice.application.usecase.GetOrderDetailUseCase
+import com.koosco.orderservice.domain.enums.OrderStatus
+import com.koosco.orderservice.domain.vo.Money
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+/**
+ * Integration test for order creation using real MariaDB + Kafka containers.
+ *
+ * Verifies:
+ * - Order is persisted correctly with all fields
+ * - Order starts in CREATED status
+ * - Order items are saved correctly
+ * - Idempotency key prevents duplicate order creation
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class CreateOrderIntegrationTest : IntegrationTestBase() {
+
+    @Autowired
+    private lateinit var createOrderUseCase: CreateOrderUseCase
+
+    @Autowired
+    private lateinit var getOrderDetailUseCase: GetOrderDetailUseCase
+
+    @Test
+    fun `should create order and persist it in database`() {
+        // given
+        val userId = 1L
+        val command = CreateOrderCommand(
+            userId = userId,
+            idempotencyKey = null,
+            items = listOf(
+                CreateOrderCommand.OrderItemCommand(
+                    skuId = 100L,
+                    productId = 10L,
+                    brandId = 1L,
+                    titleSnapshot = "Test Product",
+                    optionSnapshot = "Color: Red",
+                    quantity = 2,
+                    unitPrice = Money(10000L),
+                ),
+            ),
+            discountAmount = Money(0L),
+            shippingFee = Money(3000L),
+            shippingAddress = CreateOrderCommand.ShippingAddressCommand(
+                recipient = "John Doe",
+                phone = "010-1234-5678",
+                zipCode = "12345",
+                address = "Seoul, Korea",
+                addressDetail = "Apt 101",
+            ),
+        )
+
+        // when
+        val result = createOrderUseCase.execute(command)
+
+        // then
+        assertNotNull(result.orderId)
+        assertTrue(result.orderNo.startsWith("ORD-"))
+        assertEquals(OrderStatus.CREATED, result.status)
+        assertEquals(23000L, result.totalAmount) // 10000 * 2 + 3000 shipping
+
+        // verify persistence using GetOrderDetailUseCase (handles transaction scope)
+        val detail = getOrderDetailUseCase.execute(result.orderId)
+        assertNotNull(detail)
+        assertEquals(userId, detail.userId)
+        assertEquals(1, detail.items.size)
+        assertEquals(2, detail.items[0].qty)
+    }
+
+    @Test
+    fun `should return same order for duplicate idempotency key`() {
+        // given
+        val userId = 2L
+        val idempotencyKey = "test-idempotency-key-001"
+        val command = CreateOrderCommand(
+            userId = userId,
+            idempotencyKey = idempotencyKey,
+            items = listOf(
+                CreateOrderCommand.OrderItemCommand(
+                    skuId = 200L,
+                    productId = 20L,
+                    brandId = 2L,
+                    titleSnapshot = "Another Product",
+                    optionSnapshot = null,
+                    quantity = 1,
+                    unitPrice = Money(5000L),
+                ),
+            ),
+            discountAmount = Money(0L),
+            shippingFee = Money(0L),
+            shippingAddress = CreateOrderCommand.ShippingAddressCommand(
+                recipient = "Jane Doe",
+                phone = "010-9876-5432",
+                zipCode = "54321",
+                address = "Busan, Korea",
+                addressDetail = "Apt 202",
+            ),
+        )
+
+        // when
+        val firstResult = createOrderUseCase.execute(command)
+        val secondResult = createOrderUseCase.execute(command)
+
+        // then
+        assertEquals(firstResult.orderId, secondResult.orderId)
+        assertEquals(firstResult.orderNo, secondResult.orderNo)
+    }
+}


### PR DESCRIPTION
## Summary
- MariaDB/Redis Testcontainers 베이스 클래스 추가 (common-core testFixtures)
- IntegrationTestBase: MariaDB + Redis + Kafka 통합 베이스 클래스
- P1 통합 테스트: inventory-service (재고), order-service (주문), catalog-service (카테고리)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)