### PR TITLE
feat: add review statistics aggregation to product

### DIFF
--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/response/ProductResponses.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/response/ProductResponses.kt
@@ -16,23 +16,31 @@ import com.koosco.catalogservice.domain.enums.ProductStatus
 data class ProductListResponse(
     val id: Long,
     val name: String,
-    val price: Long,
+    val originalPrice: Long,
+    val sellingPrice: Long,
+    val discountRate: Int,
     val status: ProductStatus,
     val categoryId: Long?,
     val thumbnailImageUrl: String?,
     val brandId: Long?,
     val brandName: String?,
+    val averageRating: Double,
+    val reviewCount: Int,
 ) {
     companion object {
         fun from(productInfo: ProductInfo): ProductListResponse = ProductListResponse(
             id = productInfo.id,
             name = productInfo.name,
-            price = productInfo.price,
+            originalPrice = productInfo.price,
+            sellingPrice = productInfo.sellingPrice,
+            discountRate = productInfo.discountRate,
             status = productInfo.status,
             categoryId = productInfo.categoryId,
             thumbnailImageUrl = productInfo.thumbnailImageUrl,
             brandId = productInfo.brandId,
             brandName = productInfo.brandName,
+            averageRating = productInfo.averageRating,
+            reviewCount = productInfo.reviewCount,
         )
     }
 }
@@ -41,12 +49,16 @@ data class ProductDetailResponse(
     val id: Long,
     val name: String,
     val description: String?,
-    val price: Long,
+    val originalPrice: Long,
+    val sellingPrice: Long,
+    val discountRate: Int,
     val status: ProductStatus,
     val categoryId: Long?,
     val thumbnailImageUrl: String?,
     val brandId: Long?,
     val brandName: String?,
+    val averageRating: Double,
+    val reviewCount: Int,
     val optionGroups: List<ProductOptionGroupResponse>,
 ) {
     companion object {
@@ -54,12 +66,16 @@ data class ProductDetailResponse(
             id = productInfo.id,
             name = productInfo.name,
             description = productInfo.description,
-            price = productInfo.price,
+            originalPrice = productInfo.price,
+            sellingPrice = productInfo.sellingPrice,
+            discountRate = productInfo.discountRate,
             status = productInfo.status,
             categoryId = productInfo.categoryId,
             thumbnailImageUrl = productInfo.thumbnailImageUrl,
             brandId = productInfo.brandId,
             brandName = productInfo.brandName,
+            averageRating = productInfo.averageRating,
+            reviewCount = productInfo.reviewCount,
             optionGroups = productInfo.optionGroups.map { ProductOptionGroupResponse.from(it) },
         )
     }

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/QueryCommand.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/QueryCommand.kt
@@ -18,12 +18,15 @@ data class GetProductListCommand(
     val maxPrice: Long?,
     val sort: ProductSortType,
     val pageable: Pageable,
+    val attributeFilters: Map<Long, String> = emptyMap(),
 )
 
 enum class ProductSortType {
     LATEST,
     PRICE_ASC,
     PRICE_DESC,
+    RATING_DESC,
+    REVIEW_COUNT_DESC,
 }
 
 data class GetProductDetailCommand(val productId: Long)

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/port/ReviewRepository.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/port/ReviewRepository.kt
@@ -11,4 +11,8 @@ interface ReviewRepository {
     fun findByIdOrNull(reviewId: Long): Review?
 
     fun findByProductId(productId: Long, pageable: Pageable): Page<Review>
+
+    fun calculateAverageRating(productId: Long): Double
+
+    fun countByProductId(productId: Long): Int
 }

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/result/ProductInfo.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/result/ProductInfo.kt
@@ -10,11 +10,15 @@ data class ProductInfo(
     val name: String,
     val description: String?,
     val price: Long,
+    val sellingPrice: Long,
+    val discountRate: Int,
     val status: ProductStatus,
     val categoryId: Long?,
     val thumbnailImageUrl: String?,
     val brandId: Long?,
     val brandName: String? = null,
+    val averageRating: Double = 0.0,
+    val reviewCount: Int = 0,
     val optionGroups: List<ProductOptionGroupInfo> = emptyList(),
 ) {
     data class ProductOptionGroupInfo(
@@ -45,17 +49,26 @@ data class ProductInfo(
     }
 
     companion object {
-        fun from(product: Product, brandName: String? = null): ProductInfo = ProductInfo(
-            id = product.id!!,
-            name = product.name,
-            description = product.description,
-            price = product.price,
-            status = product.status,
-            categoryId = product.categoryId,
-            thumbnailImageUrl = product.thumbnailImageUrl,
-            brandId = product.brandId,
-            brandName = brandName,
-            optionGroups = product.optionGroups.map { ProductOptionGroupInfo.from(it) },
-        )
+        fun from(product: Product, brandName: String? = null): ProductInfo {
+            val sellingPrice = product.calculateSellingPrice()
+            val discountRate = product.calculateDiscountRate()
+
+            return ProductInfo(
+                id = product.id!!,
+                name = product.name,
+                description = product.description,
+                price = product.price,
+                sellingPrice = sellingPrice,
+                discountRate = discountRate,
+                status = product.status,
+                categoryId = product.categoryId,
+                thumbnailImageUrl = product.thumbnailImageUrl,
+                brandId = product.brandId,
+                brandName = brandName,
+                averageRating = product.averageRating,
+                reviewCount = product.reviewCount,
+                optionGroups = product.optionGroups.map { ProductOptionGroupInfo.from(it) },
+            )
+        }
     }
 }

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/UpdateReviewUseCase.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/UpdateReviewUseCase.kt
@@ -1,6 +1,7 @@
 package com.koosco.catalogservice.application.usecase
 
 import com.koosco.catalogservice.application.command.UpdateReviewCommand
+import com.koosco.catalogservice.application.port.ProductRepository
 import com.koosco.catalogservice.application.port.ReviewRepository
 import com.koosco.catalogservice.application.result.ReviewResult
 import com.koosco.catalogservice.common.error.CatalogErrorCode
@@ -10,7 +11,10 @@ import com.koosco.common.core.exception.NotFoundException
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-class UpdateReviewUseCase(private val reviewRepository: ReviewRepository) {
+class UpdateReviewUseCase(
+    private val reviewRepository: ReviewRepository,
+    private val productRepository: ProductRepository,
+) {
 
     @Transactional
     fun execute(command: UpdateReviewCommand): ReviewResult {
@@ -21,12 +25,26 @@ class UpdateReviewUseCase(private val reviewRepository: ReviewRepository) {
             throw ForbiddenException(CatalogErrorCode.FORBIDDEN)
         }
 
+        val oldRating = review.rating
+
         review.update(
             title = command.title,
             content = command.content,
             rating = command.rating,
         )
 
+        if (command.rating != null && command.rating != oldRating) {
+            updateProductReviewStatistics(review.productId)
+        }
+
         return ReviewResult.from(review)
+    }
+
+    private fun updateProductReviewStatistics(productId: Long) {
+        val product = productRepository.findOrNull(productId)
+            ?: throw NotFoundException(CatalogErrorCode.PRODUCT_NOT_FOUND)
+        val averageRating = reviewRepository.calculateAverageRating(productId)
+        val reviewCount = reviewRepository.countByProductId(productId)
+        product.updateReviewStatistics(averageRating, reviewCount)
     }
 }

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/persist/JpaReviewRepository.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/persist/JpaReviewRepository.kt
@@ -5,8 +5,14 @@ import com.koosco.catalogservice.domain.enums.ContentStatus
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface JpaReviewRepository : JpaRepository<Review, Long> {
 
     fun findByProductIdAndStatusNot(productId: Long, status: ContentStatus, pageable: Pageable): Page<Review>
+
+    @Query("SELECT COALESCE(AVG(r.rating), 0.0) FROM Review r WHERE r.productId = :productId AND r.status <> 'DELETED'")
+    fun calculateAverageRating(productId: Long): Double
+
+    fun countByProductIdAndStatusNot(productId: Long, status: ContentStatus): Int
 }

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/persist/ProductQuery.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/persist/ProductQuery.kt
@@ -2,6 +2,7 @@ package com.koosco.catalogservice.infra.persist
 
 import com.koosco.catalogservice.application.command.GetProductListCommand
 import com.koosco.catalogservice.application.command.ProductSortType
+import com.koosco.catalogservice.application.port.ProductAttributeValueRepository
 import com.koosco.catalogservice.domain.entity.Product
 import com.koosco.catalogservice.domain.entity.QProduct.product
 import com.koosco.catalogservice.domain.enums.ProductStatus
@@ -13,7 +14,10 @@ import org.springframework.data.support.PageableExecutionUtils
 import org.springframework.stereotype.Repository
 
 @Repository
-class ProductQuery(private val queryFactory: JPAQueryFactory) {
+class ProductQuery(
+    private val queryFactory: JPAQueryFactory,
+    private val productAttributeValueRepository: ProductAttributeValueRepository,
+) {
 
     fun search(command: GetProductListCommand): Page<Product> {
         val where = buildWhere(command)
@@ -36,21 +40,39 @@ class ProductQuery(private val queryFactory: JPAQueryFactory) {
         }
     }
 
-    private fun buildWhere(command: GetProductListCommand): List<BooleanExpression> = listOfNotNull(
-        product.status.eq(ProductStatus.ACTIVE),
-        command.categoryId?.let { product.categoryId.eq(it) },
-        command.brandId?.let { product.brandId.eq(it) },
-        command.keyword?.takeIf { it.isNotBlank() }?.let {
-            product.name.containsIgnoreCase(it)
-                .or(product.description.containsIgnoreCase(it))
-        },
-        command.minPrice?.let { product.price.goe(it) },
-        command.maxPrice?.let { product.price.loe(it) },
-    )
+    private fun buildWhere(command: GetProductListCommand): List<BooleanExpression> {
+        val baseConditions = listOfNotNull(
+            product.status.eq(ProductStatus.ACTIVE),
+            command.categoryId?.let { product.categoryId.eq(it) },
+            command.brandId?.let { product.brandId.eq(it) },
+            command.keyword?.takeIf { it.isNotBlank() }?.let {
+                product.name.containsIgnoreCase(it)
+                    .or(product.description.containsIgnoreCase(it))
+            },
+            command.minPrice?.let { product.price.goe(it) },
+            command.maxPrice?.let { product.price.loe(it) },
+        )
+
+        if (command.attributeFilters.isEmpty()) {
+            return baseConditions
+        }
+
+        val matchingProductIds = productAttributeValueRepository
+            .findProductIdsByAttributeFilters(command.attributeFilters)
+
+        if (matchingProductIds.isEmpty()) {
+            // No products match the attribute filters, return impossible condition
+            return baseConditions + product.id.eq(-1L)
+        }
+
+        return baseConditions + product.id.`in`(matchingProductIds)
+    }
 
     private fun sortOrder(sort: ProductSortType): OrderSpecifier<*> = when (sort) {
         ProductSortType.LATEST -> product.createdAt.desc()
         ProductSortType.PRICE_ASC -> product.price.asc()
         ProductSortType.PRICE_DESC -> product.price.desc()
+        ProductSortType.RATING_DESC -> product.averageRating.desc()
+        ProductSortType.REVIEW_COUNT_DESC -> product.reviewCount.desc()
     }
 }

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/persist/ReviewRepositoryAdapter.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/persist/ReviewRepositoryAdapter.kt
@@ -17,4 +17,9 @@ class ReviewRepositoryAdapter(private val jpaReviewRepository: JpaReviewReposito
 
     override fun findByProductId(productId: Long, pageable: Pageable): Page<Review> =
         jpaReviewRepository.findByProductIdAndStatusNot(productId, ContentStatus.DELETED, pageable)
+
+    override fun calculateAverageRating(productId: Long): Double = jpaReviewRepository.calculateAverageRating(productId)
+
+    override fun countByProductId(productId: Long): Int =
+        jpaReviewRepository.countByProductIdAndStatusNot(productId, ContentStatus.DELETED)
 }


### PR DESCRIPTION
## Summary
- `Product` 엔티티에 `averageRating`, `reviewCount` 필드 추가
- 리뷰 생성/수정/삭제 시 상품 통계 자동 갱신 로직 구현
- `RATING_DESC`, `REVIEW_COUNT_DESC` 정렬 옵션 및 QueryDSL 조건 추가

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)