### PR TITLE
feat: K8s CronJob 배치 작업 분리

### DIFF
--- a/infra/k8s/batch/inventory-snapshot-cronjob.yaml
+++ b/infra/k8s/batch/inventory-snapshot-cronjob.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: inventory-snapshot
+  namespace: commerce
+  labels:
+    app: inventory-snapshot
+    app.kubernetes.io/part-of: commerce
+spec:
+  schedule: "*/1 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 120
+      template:
+        metadata:
+          labels:
+            app: inventory-snapshot
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: inventory-snapshot
+              image: inventory-service:latest
+              imagePullPolicy: Never
+              envFrom:
+                - configMapRef:
+                    name: commerce-common-config
+                - secretRef:
+                    name: commerce-common-secret
+              env:
+                - name: DB_NAME
+                  value: commerce-inventory
+                - name: SPRING_PROFILES_ACTIVE
+                  value: batch
+                - name: JAVA_OPTS
+                  value: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=65.0 -XX:InitialRAMPercentage=50.0 -XX:+UseG1GC -XX:+DisableExplicitGC -Djava.security.egd=file:/dev/./urandom"
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "50m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "200m"

--- a/services/inventory-service/src/main/kotlin/com/koosco/inventoryservice/infra/batch/InventorySnapshotScheduler.kt
+++ b/services/inventory-service/src/main/kotlin/com/koosco/inventoryservice/infra/batch/InventorySnapshotScheduler.kt
@@ -2,6 +2,7 @@ package com.koosco.inventoryservice.infra.batch
 
 import com.koosco.inventoryservice.application.port.InventorySnapshotWriter
 import com.koosco.inventoryservice.application.port.InventoryStockSnapshotQueryPort
+import org.springframework.context.annotation.Profile
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Component
  * date           : 2025. 12. 29. 오전 5:09
  * description    :
  */
+@Profile("batch")
 @Component
 class InventorySnapshotScheduler(
     private val snapshotQuery: InventoryStockSnapshotQueryPort,


### PR DESCRIPTION
## Summary
- inventory-service의 `InventorySnapshotScheduler`에 `@Profile("batch")` 추가하여 API 서비스에서 스케줄러 비활성화
- K8s CronJob 매니페스트(`infra/k8s/batch/inventory-snapshot-cronjob.yaml`) 추가
- `concurrencyPolicy: Forbid`로 중복 실행 방지, 동일 이미지에 `SPRING_PROFILES_ACTIVE=batch`로 프로파일 분리

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)