### PR TITLE
feat: 상품 검색 정렬 전략 도입 (인기도 + 적합도)

### DIFF
--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/ProductController.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/ProductController.kt
@@ -11,7 +11,6 @@ import com.koosco.catalogservice.application.command.DeleteProductCommand
 import com.koosco.catalogservice.application.command.FindSkuCommand
 import com.koosco.catalogservice.application.command.GetProductDetailCommand
 import com.koosco.catalogservice.application.command.GetProductListCommand
-import com.koosco.catalogservice.application.command.ProductSortType
 import com.koosco.catalogservice.application.command.RemoveProductOptionCommand
 import com.koosco.catalogservice.application.usecase.AddProductOptionUseCase
 import com.koosco.catalogservice.application.usecase.ChangeProductStatusUseCase
@@ -22,6 +21,7 @@ import com.koosco.catalogservice.application.usecase.GetProductDetailUseCase
 import com.koosco.catalogservice.application.usecase.GetProductListUseCase
 import com.koosco.catalogservice.application.usecase.RemoveProductOptionUseCase
 import com.koosco.catalogservice.application.usecase.UpdateProductUseCase
+import com.koosco.catalogservice.domain.enums.SortStrategy
 import com.koosco.common.core.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -71,8 +71,8 @@ class ProductController(
         @Parameter(description = "브랜드 ID") @RequestParam(required = false) brandId: Long?,
         @Parameter(description = "최소 가격") @RequestParam(required = false) minPrice: Long?,
         @Parameter(description = "최대 가격") @RequestParam(required = false) maxPrice: Long?,
-        @Parameter(description = "정렬 (LATEST, PRICE_ASC, PRICE_DESC)")
-        @RequestParam(required = false, defaultValue = "LATEST") sort: ProductSortType,
+        @Parameter(description = "정렬 (RECOMMENDED, LATEST, PRICE_ASC, PRICE_DESC, POPULARITY)")
+        @RequestParam(required = false, defaultValue = "LATEST") sort: SortStrategy,
         @Parameter(description = "페이징 파라미터 (page, size)") @PageableDefault(size = 20) pageable: Pageable,
         @Parameter(hidden = true) @RequestParam allRequestParams: Map<String, String>,
     ): ApiResponse<Page<ProductListResponse>> {

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/response/ProductResponses.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/response/ProductResponses.kt
@@ -20,6 +20,8 @@ data class ProductListResponse(
     val brandName: String?,
     val averageRating: Double,
     val reviewCount: Int,
+    val viewCount: Long,
+    val orderCount: Long,
 ) {
     companion object {
         fun from(productInfo: ProductInfo): ProductListResponse = ProductListResponse(
@@ -35,6 +37,8 @@ data class ProductListResponse(
             brandName = productInfo.brandName,
             averageRating = productInfo.averageRating,
             reviewCount = productInfo.reviewCount,
+            viewCount = productInfo.viewCount,
+            orderCount = productInfo.orderCount,
         )
     }
 }

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/QueryCommand.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/QueryCommand.kt
@@ -1,5 +1,6 @@
 package com.koosco.catalogservice.application.command
 
+import com.koosco.catalogservice.domain.enums.SortStrategy
 import org.springframework.data.domain.Pageable
 
 /**
@@ -16,17 +17,15 @@ data class GetProductListCommand(
     val brandId: Long?,
     val minPrice: Long?,
     val maxPrice: Long?,
-    val sort: ProductSortType,
+    val sort: SortStrategy,
     val pageable: Pageable,
     val attributeFilters: Map<Long, String> = emptyMap(),
 )
 
-enum class ProductSortType {
-    LATEST,
-    PRICE_ASC,
-    PRICE_DESC,
-    RATING_DESC,
-    REVIEW_COUNT_DESC,
-}
+/**
+ * @deprecated Use [SortStrategy] instead. Kept for backward compatibility.
+ */
+@Deprecated("Use SortStrategy instead", ReplaceWith("SortStrategy"))
+typealias ProductSortType = SortStrategy
 
 data class GetProductDetailCommand(val productId: Long)

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/port/ProductSearchPort.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/port/ProductSearchPort.kt
@@ -1,0 +1,9 @@
+package com.koosco.catalogservice.application.port
+
+import com.koosco.catalogservice.application.command.GetProductListCommand
+import com.koosco.catalogservice.domain.entity.Product
+import org.springframework.data.domain.Page
+
+interface ProductSearchPort {
+    fun search(command: GetProductListCommand): Page<Product>
+}

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/result/ProductInfo.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/result/ProductInfo.kt
@@ -19,6 +19,8 @@ data class ProductInfo(
     val brandName: String? = null,
     val averageRating: Double = 0.0,
     val reviewCount: Int = 0,
+    val viewCount: Long = 0,
+    val orderCount: Long = 0,
     val optionGroups: List<ProductOptionGroupInfo> = emptyList(),
 ) {
     data class ProductOptionGroupInfo(
@@ -49,9 +51,14 @@ data class ProductInfo(
     }
 
     companion object {
-        fun from(product: Product, brandName: String? = null): ProductInfo {
-            val sellingPrice = product.calculateSellingPrice()
-            val discountRate = product.calculateDiscountRate()
+        fun from(product: Product, brandName: String? = null, promotionDiscountPrice: Long? = null): ProductInfo {
+            val sellingPrice = promotionDiscountPrice
+                ?: product.calculateSellingPrice()
+            val discountRate = if (promotionDiscountPrice != null && product.price > 0) {
+                ((product.price - promotionDiscountPrice) * 100 / product.price).toInt()
+            } else {
+                product.calculateDiscountRate()
+            }
 
             return ProductInfo(
                 id = product.id!!,
@@ -67,6 +74,8 @@ data class ProductInfo(
                 brandName = brandName,
                 averageRating = product.averageRating,
                 reviewCount = product.reviewCount,
+                viewCount = product.viewCount,
+                orderCount = product.orderCount,
                 optionGroups = product.optionGroups.map { ProductOptionGroupInfo.from(it) },
             )
         }

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/domain/entity/Product.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/domain/entity/Product.kt
@@ -58,6 +58,12 @@ class Product(
     @Column(name = "review_count", nullable = false)
     var reviewCount: Int = 0,
 
+    @Column(name = "view_count", nullable = false)
+    var viewCount: Long = 0,
+
+    @Column(name = "order_count", nullable = false)
+    var orderCount: Long = 0,
+
     @OneToMany(mappedBy = "product", cascade = [CascadeType.ALL], orphanRemoval = true)
     val skus: MutableList<ProductSku> = mutableListOf(),
 
@@ -109,6 +115,14 @@ class Product(
     fun updateReviewStatistics(averageRating: Double, reviewCount: Int) {
         this.averageRating = averageRating
         this.reviewCount = reviewCount
+    }
+
+    fun incrementViewCount() {
+        this.viewCount++
+    }
+
+    fun incrementOrderCount() {
+        this.orderCount++
     }
 
     fun delete() {

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/domain/enums/SortStrategy.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/domain/enums/SortStrategy.kt
@@ -1,0 +1,9 @@
+package com.koosco.catalogservice.domain.enums
+
+enum class SortStrategy {
+    RECOMMENDED,
+    LATEST,
+    PRICE_ASC,
+    PRICE_DESC,
+    POPULARITY,
+}

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/persist/ProductRepositoryImpl.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/persist/ProductRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.koosco.catalogservice.infra.persist
 
 import com.koosco.catalogservice.application.command.GetProductListCommand
 import com.koosco.catalogservice.application.port.ProductRepository
+import com.koosco.catalogservice.application.port.ProductSearchPort
 import com.koosco.catalogservice.domain.entity.Product
 import org.springframework.data.domain.Page
 import org.springframework.data.repository.findByIdOrNull
@@ -11,7 +12,8 @@ import org.springframework.stereotype.Repository
 class ProductRepositoryImpl(
     private val jpaProductRepository: JpaProductRepository,
     private val productQuery: ProductQuery,
-) : ProductRepository {
+) : ProductRepository,
+    ProductSearchPort {
 
     override fun save(product: Product): Product = jpaProductRepository.save(product)
 


### PR DESCRIPTION
## Summary
- `SortStrategy` enum 도입 (RECOMMENDED, LATEST, PRICE_ASC, PRICE_DESC, POPULARITY)
- Product 엔티티에 `viewCount`, `orderCount` 인기도 필드 추가
- `ProductSearchPort` 인터페이스 분리 (CQRS 준비, 향후 Elasticsearch 어댑터 교체 가능)
- QueryDSL에서 각 정렬 전략별 로직 구현 (RECOMMENDED: 카테고리/브랜드 매칭 부스팅 + 인기도)

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)