### PR TITLE
feat: 사용자 행동 이벤트 수집 파이프라인

### DIFF
--- a/common/common-core/src/main/kotlin/com/koosco/common/core/event/BehaviorType.kt
+++ b/common/common-core/src/main/kotlin/com/koosco/common/core/event/BehaviorType.kt
@@ -1,0 +1,12 @@
+package com.koosco.common.core.event
+
+/**
+ * 사용자 행동 유형을 정의하는 enum.
+ * 향후 인기 상품 정렬, 개인화 추천, A/B 테스트 등에 활용.
+ */
+enum class BehaviorType {
+    VIEW,
+    CART_ADD,
+    PURCHASE,
+    SEARCH,
+}

--- a/common/common-core/src/main/kotlin/com/koosco/common/core/event/UserBehaviorEvent.kt
+++ b/common/common-core/src/main/kotlin/com/koosco/common/core/event/UserBehaviorEvent.kt
@@ -1,0 +1,13 @@
+package com.koosco.common.core.event
+
+/**
+ * 사용자 행동 이벤트 데이터.
+ * 각 서비스에서 발행하여 사용자 행동 데이터를 수집하는 파이프라인의 기반.
+ */
+data class UserBehaviorEvent(
+    val userId: Long,
+    val behaviorType: BehaviorType,
+    val productId: Long?,
+    val searchQuery: String?,
+    val metadata: Map<String, String> = emptyMap(),
+)

--- a/services/catalog-service/build.gradle.kts
+++ b/services/catalog-service/build.gradle.kts
@@ -38,6 +38,9 @@ dependencies {
     // caffeine cache
     implementation("com.github.ben-manes.caffeine:caffeine")
 
+    // redis
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
     // common
     implementation(project(":common:common-core"))
     implementation(project(":common:common-security"))

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/ProductController.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/ProductController.kt
@@ -23,6 +23,7 @@ import com.koosco.catalogservice.application.usecase.RemoveProductOptionUseCase
 import com.koosco.catalogservice.application.usecase.UpdateProductUseCase
 import com.koosco.catalogservice.domain.enums.SortStrategy
 import com.koosco.common.core.response.ApiResponse
+import com.koosco.commonsecurity.resolver.AuthId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
@@ -75,6 +76,7 @@ class ProductController(
         @RequestParam(required = false, defaultValue = "LATEST") sort: SortStrategy,
         @Parameter(description = "페이징 파라미터 (page, size)") @PageableDefault(size = 20) pageable: Pageable,
         @Parameter(hidden = true) @RequestParam allRequestParams: Map<String, String>,
+        @Parameter(hidden = true) @AuthId userId: Long?,
     ): ApiResponse<Page<ProductListResponse>> {
         val attributeFilters = allRequestParams
             .filter { it.key.startsWith("attr.") }
@@ -91,6 +93,7 @@ class ProductController(
             sort = sort,
             pageable = pageable,
             attributeFilters = attributeFilters,
+            userId = userId,
         )
 
         return ApiResponse.success(
@@ -104,8 +107,9 @@ class ProductController(
     @GetMapping("/{productId}")
     fun getProduct(
         @Parameter(description = "Product ID") @PathVariable productId: Long,
+        @Parameter(hidden = true) @AuthId userId: Long?,
     ): ApiResponse<ProductDetailResponse> {
-        val command = GetProductDetailCommand(productId = productId)
+        val command = GetProductDetailCommand(productId = productId, userId = userId)
         val productInfo = getProductDetailUseCase.execute(command)
 
         return ApiResponse.Companion.success(ProductDetailResponse.Companion.from(productInfo))

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/QueryCommand.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/QueryCommand.kt
@@ -20,6 +20,7 @@ data class GetProductListCommand(
     val sort: SortStrategy,
     val pageable: Pageable,
     val attributeFilters: Map<Long, String> = emptyMap(),
+    val userId: Long? = null,
 )
 
 /**
@@ -28,4 +29,4 @@ data class GetProductListCommand(
 @Deprecated("Use SortStrategy instead", ReplaceWith("SortStrategy"))
 typealias ProductSortType = SortStrategy
 
-data class GetProductDetailCommand(val productId: Long)
+data class GetProductDetailCommand(val productId: Long, val userId: Long? = null)

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/port/UserBehaviorEventProducer.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/port/UserBehaviorEventProducer.kt
@@ -1,0 +1,11 @@
+package com.koosco.catalogservice.application.port
+
+import com.koosco.common.core.event.UserBehaviorEvent
+
+/**
+ * 사용자 행동 이벤트 발행 포트.
+ * 분석 목적의 이벤트로 outbox 패턴 대신 직접 Kafka 발행.
+ */
+interface UserBehaviorEventProducer {
+    fun publish(event: UserBehaviorEvent)
+}

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/messaging/kafka/consumer/KafkaUserBehaviorEventConsumer.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/messaging/kafka/consumer/KafkaUserBehaviorEventConsumer.kt
@@ -1,0 +1,77 @@
+package com.koosco.catalogservice.infra.messaging.kafka.consumer
+
+import com.koosco.common.core.event.CloudEvent
+import com.koosco.common.core.event.UserBehaviorEvent
+import com.koosco.common.core.util.JsonUtils.objectMapper
+import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+import org.springframework.validation.annotation.Validated
+
+/**
+ * 사용자 행동 이벤트를 소비하여 상품별 조회수를 Redis에 집계한다.
+ * VIEW 이벤트만 처리하며 productId가 있는 경우에만 카운트를 증가시킨다.
+ */
+@Component
+@Validated
+class KafkaUserBehaviorEventConsumer(private val redisTemplate: StringRedisTemplate) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @KafkaListener(
+        topics = ["\${catalog.topic.consumer.user-behavior}"],
+        groupId = "\${spring.kafka.consumer.group-id}",
+    )
+    fun onUserBehaviorEvent(@Valid event: CloudEvent<*>, ack: Acknowledgment) {
+        val payload = event.data
+            ?: run {
+                logger.error("UserBehaviorEvent data is null: eventId=${event.id}")
+                ack.acknowledge()
+                return
+            }
+
+        try {
+            when (event.type) {
+                EVENT_TYPE_VIEW -> handleViewEvent(event, payload)
+                else -> logger.debug("Ignoring unhandled behavior event type: ${event.type}")
+            }
+        } catch (e: Exception) {
+            logger.error(
+                "Failed to process user behavior event: eventId=${event.id}, type=${event.type}",
+                e,
+            )
+            throw e
+        }
+
+        ack.acknowledge()
+    }
+
+    private fun handleViewEvent(event: CloudEvent<*>, payload: Any) {
+        val behaviorEvent = try {
+            objectMapper.convertValue(payload, UserBehaviorEvent::class.java)
+        } catch (e: Exception) {
+            logger.error("Failed to deserialize UserBehaviorEvent: eventId=${event.id}", e)
+            return
+        }
+
+        val productId = behaviorEvent.productId ?: return
+
+        redisTemplate.opsForValue().increment(viewCountKey(productId))
+
+        logger.debug(
+            "Incremented view count: productId={}, userId={}",
+            productId,
+            behaviorEvent.userId,
+        )
+    }
+
+    companion object {
+        private const val EVENT_TYPE_VIEW = "user.behavior.view"
+        private const val VIEW_COUNT_PREFIX = "catalog:product:viewCount:"
+
+        fun viewCountKey(productId: Long): String = "$VIEW_COUNT_PREFIX$productId"
+    }
+}

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/messaging/kafka/producer/KafkaUserBehaviorEventProducer.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/messaging/kafka/producer/KafkaUserBehaviorEventProducer.kt
@@ -1,0 +1,54 @@
+package com.koosco.catalogservice.infra.messaging.kafka.producer
+
+import com.koosco.catalogservice.application.port.UserBehaviorEventProducer
+import com.koosco.common.core.event.CloudEvent
+import com.koosco.common.core.event.UserBehaviorEvent
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+
+/**
+ * Kafka 기반 사용자 행동 이벤트 발행.
+ * 분석 목적의 이벤트이므로 outbox 패턴 대신 직접 Kafka로 발행한다.
+ * userId 기반 파티셔닝을 통해 동일 사용자의 이벤트가 같은 파티션으로 전달된다.
+ */
+@Component
+class KafkaUserBehaviorEventProducer(
+    private val kafkaTemplate: KafkaTemplate<String, CloudEvent<*>>,
+
+    @Value("\${catalog.topic.user-behavior:user-behavior-events}")
+    private val topic: String,
+
+    @Value("\${spring.application.name}")
+    private val source: String,
+) : UserBehaviorEventProducer {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun publish(event: UserBehaviorEvent) {
+        val cloudEvent = CloudEvent.of(
+            source = source,
+            type = "user.behavior.${event.behaviorType.name.lowercase()}",
+            subject = "user/${event.userId}",
+            data = event,
+        )
+
+        try {
+            kafkaTemplate.send(topic, event.userId.toString(), cloudEvent)
+            logger.debug(
+                "Published user behavior event: type={}, userId={}, productId={}",
+                event.behaviorType,
+                event.userId,
+                event.productId,
+            )
+        } catch (e: Exception) {
+            logger.warn(
+                "Failed to publish user behavior event: type={}, userId={}",
+                event.behaviorType,
+                event.userId,
+                e,
+            )
+        }
+    }
+}

--- a/services/catalog-service/src/main/resources/application.yaml
+++ b/services/catalog-service/src/main/resources/application.yaml
@@ -28,6 +28,10 @@ spring:
           batch_size: 20
         order_inserts: true
         order_updates: true
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
   datasource:
     url: jdbc:mariadb://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:commerce-catalog}
     username: ${DB_USERNAME:admin}
@@ -66,6 +70,7 @@ jwt:
 catalog:
   topic:
     default: koosco.commerce.catalog.default
+    user-behavior: user-behavior-events
     mappings:
       "product.sku.created": koosco.commerce.product.default
       "product.status.changed": koosco.commerce.product.default
@@ -73,6 +78,7 @@ catalog:
     consumer:
       inventory:
         stock: koosco.commerce.inventory.stock
+      user-behavior: user-behavior-events
 
 common:
   openapi:

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/application/port/UserBehaviorEventProducer.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/application/port/UserBehaviorEventProducer.kt
@@ -1,0 +1,11 @@
+package com.koosco.orderservice.application.port
+
+import com.koosco.common.core.event.UserBehaviorEvent
+
+/**
+ * 사용자 행동 이벤트 발행 포트.
+ * 분석 목적의 이벤트로 outbox 패턴 대신 직접 Kafka 발행.
+ */
+interface UserBehaviorEventProducer {
+    fun publish(event: UserBehaviorEvent)
+}

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/infra/messaging/kafka/producer/KafkaUserBehaviorEventProducer.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/infra/messaging/kafka/producer/KafkaUserBehaviorEventProducer.kt
@@ -1,0 +1,54 @@
+package com.koosco.orderservice.infra.messaging.kafka.producer
+
+import com.koosco.common.core.event.CloudEvent
+import com.koosco.common.core.event.UserBehaviorEvent
+import com.koosco.orderservice.application.port.UserBehaviorEventProducer
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+
+/**
+ * Kafka 기반 사용자 행동 이벤트 발행.
+ * 분석 목적의 이벤트이므로 outbox 패턴 대신 직접 Kafka로 발행한다.
+ * userId 기반 파티셔닝을 통해 동일 사용자의 이벤트가 같은 파티션으로 전달된다.
+ */
+@Component
+class KafkaUserBehaviorEventProducer(
+    private val kafkaTemplate: KafkaTemplate<String, CloudEvent<*>>,
+
+    @Value("\${order.topic.user-behavior:user-behavior-events}")
+    private val topic: String,
+
+    @Value("\${spring.application.name}")
+    private val source: String,
+) : UserBehaviorEventProducer {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun publish(event: UserBehaviorEvent) {
+        val cloudEvent = CloudEvent.of(
+            source = source,
+            type = "user.behavior.${event.behaviorType.name.lowercase()}",
+            subject = "user/${event.userId}",
+            data = event,
+        )
+
+        try {
+            kafkaTemplate.send(topic, event.userId.toString(), cloudEvent)
+            logger.debug(
+                "Published user behavior event: type={}, userId={}, productId={}",
+                event.behaviorType,
+                event.userId,
+                event.productId,
+            )
+        } catch (e: Exception) {
+            logger.warn(
+                "Failed to publish user behavior event: type={}, userId={}",
+                event.behaviorType,
+                event.userId,
+                e,
+            )
+        }
+    }
+}

--- a/services/order-service/src/main/resources/application.yaml
+++ b/services/order-service/src/main/resources/application.yaml
@@ -69,6 +69,7 @@ jwt:
 order:
   topic:
     default: koosco.commerce.order.default
+    user-behavior: user-behavior-events
     mappings:
       "order.failed": koosco.commerce.order.failed
       order:


### PR DESCRIPTION
## Summary
- common-core에 `UserBehaviorEvent`, `BehaviorType` (VIEW/CART_ADD/PURCHASE/SEARCH) 정의
- catalog-service: 상품 조회 시 VIEW, 검색 시 SEARCH 이벤트 Kafka 발행
- order-service: 주문 확정 시 PURCHASE 이벤트 발행
- catalog-service에 VIEW 이벤트 소비 Consumer 추가 (Redis에 상품별 viewCount 집계)
- CloudEvent 포맷, userId 기반 파티셔닝, 인증된 사용자만 이벤트 발행

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)