### PR TITLE
feat: 검색 품질 지표 mAP@k 모니터링

### DIFF
--- a/infra/monitoring/grafana/dashboards/search-quality.json
+++ b/infra/monitoring/grafana/dashboards/search-quality.json
@@ -1,0 +1,360 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Search Quality - mAP@k",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "mAP@k",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 4,
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.3
+              },
+              {
+                "color": "green",
+                "value": 0.6
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "search_quality_map_at_k{application=\"catalog-service\"}",
+          "legendFormat": "mAP@{{k}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Search Quality mAP@k Trend",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 4,
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.3
+              },
+              {
+                "color": "green",
+                "value": 0.6
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 11
+      },
+      "id": 3,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "search_quality_map_at_k{application=\"catalog-service\", k=\"10\"}",
+          "legendFormat": "mAP@10",
+          "refId": "A"
+        }
+      ],
+      "title": "Current mAP@10",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 4,
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.3
+              },
+              {
+                "color": "green",
+                "value": 0.6
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 11
+      },
+      "id": 4,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "search_quality_map_at_k{application=\"catalog-service\", k=\"30\"}",
+          "legendFormat": "mAP@30",
+          "refId": "A"
+        }
+      ],
+      "title": "Current mAP@30",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 4,
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.3
+              },
+              {
+                "color": "green",
+                "value": 0.6
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 11
+      },
+      "id": 5,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "search_quality_map_at_k{application=\"catalog-service\", k=\"60\"}",
+          "legendFormat": "mAP@60",
+          "refId": "A"
+        }
+      ],
+      "title": "Current mAP@60",
+      "type": "gauge"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [
+    "catalog",
+    "search",
+    "quality"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Search Quality - mAP@k",
+  "uid": "search-quality-map",
+  "version": 1
+}

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/SearchClickController.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/SearchClickController.kt
@@ -1,0 +1,38 @@
+package com.koosco.catalogservice.api.controller
+
+import com.koosco.catalogservice.api.request.SearchClickRequest
+import com.koosco.catalogservice.application.usecase.RecordSearchClickUseCase
+import com.koosco.common.core.response.ApiResponse
+import com.koosco.commonsecurity.resolver.AuthId
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Search", description = "Search quality tracking APIs")
+@RestController
+@RequestMapping("/api/search")
+class SearchClickController(private val recordSearchClickUseCase: RecordSearchClickUseCase) {
+
+    @Operation(
+        summary = "검색 결과 클릭 로그를 기록합니다.",
+        description = "검색 품질 지표(mAP@k) 계산을 위해 사용자의 검색 클릭 이벤트를 기록합니다.",
+        security = [SecurityRequirement(name = "bearerAuth")],
+    )
+    @PostMapping("/click")
+    @ResponseStatus(HttpStatus.OK)
+    fun recordSearchClick(
+        @Valid @RequestBody request: SearchClickRequest,
+        @Parameter(hidden = true) @AuthId userId: Long,
+    ): ApiResponse<Any> {
+        recordSearchClickUseCase.execute(request.toCommand(userId))
+        return ApiResponse.success()
+    }
+}

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/request/SearchClickRequest.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/request/SearchClickRequest.kt
@@ -1,0 +1,31 @@
+package com.koosco.catalogservice.api.request
+
+import com.koosco.catalogservice.application.command.SearchClickCommand
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Positive
+
+/**
+ * 검색 결과 클릭 로그 요청.
+ */
+data class SearchClickRequest(
+    @field:NotBlank(message = "검색 쿼리는 필수입니다.")
+    val searchQuery: String,
+
+    @field:Positive(message = "상품 ID는 양수여야 합니다.")
+    val clickedProductId: Long,
+
+    @field:Min(value = 1, message = "클릭 위치는 1 이상이어야 합니다.")
+    val clickPosition: Int,
+
+    @field:Positive(message = "총 결과 수는 양수여야 합니다.")
+    val totalResults: Int,
+) {
+    fun toCommand(userId: Long): SearchClickCommand = SearchClickCommand(
+        userId = userId,
+        searchQuery = searchQuery,
+        clickedProductId = clickedProductId,
+        clickPosition = clickPosition,
+        totalResults = totalResults,
+    )
+}

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/SearchClickCommand.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/command/SearchClickCommand.kt
@@ -1,0 +1,13 @@
+package com.koosco.catalogservice.application.command
+
+/**
+ * 검색 결과에서 사용자가 클릭한 상품 데이터.
+ * mAP@k 계산을 위한 클릭 로그 수집에 사용된다.
+ */
+data class SearchClickCommand(
+    val userId: Long,
+    val searchQuery: String,
+    val clickedProductId: Long,
+    val clickPosition: Int,
+    val totalResults: Int,
+)

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/port/SearchClickLogPort.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/port/SearchClickLogPort.kt
@@ -1,0 +1,26 @@
+package com.koosco.catalogservice.application.port
+
+import com.koosco.catalogservice.application.command.SearchClickCommand
+
+/**
+ * 검색 클릭 로그 저장 및 조회 포트.
+ * mAP@k 계산을 위한 클릭 데이터를 관리한다.
+ */
+interface SearchClickLogPort {
+
+    /**
+     * 검색 클릭 로그를 저장한다.
+     */
+    fun save(command: SearchClickCommand)
+
+    /**
+     * 특정 검색 쿼리에 대해 클릭된 위치 목록을 조회한다.
+     * 반환값은 클릭된 position의 리스트(정렬됨).
+     */
+    fun getClickPositions(searchQuery: String): List<Int>
+
+    /**
+     * 모든 검색 쿼리 키를 조회한다.
+     */
+    fun getAllSearchQueries(): Set<String>
+}

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/CalculateSearchQualityUseCase.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/CalculateSearchQualityUseCase.kt
@@ -1,0 +1,70 @@
+package com.koosco.catalogservice.application.usecase
+
+import com.koosco.catalogservice.application.port.SearchClickLogPort
+import com.koosco.common.core.annotation.UseCase
+import org.slf4j.LoggerFactory
+
+/**
+ * 검색 품질 지표 mAP@k를 계산하는 유스케이스.
+ *
+ * mAP@k (Mean Average Precision at k):
+ * - 각 검색 쿼리별로 AP@k (Average Precision at k)를 계산
+ * - 전체 쿼리의 평균을 구해 mAP@k를 산출
+ *
+ * AP@k = (1/min(m,k)) * sum(Precision@i * rel(i)) for i=1..k
+ * - m: 전체 관련 문서 수 (클릭된 상품 수)
+ * - rel(i): i번째 결과가 관련 있으면 1, 아니면 0
+ * - Precision@i: 상위 i개 결과 중 관련 문서 비율
+ */
+@UseCase
+class CalculateSearchQualityUseCase(private val searchClickLogPort: SearchClickLogPort) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * 전체 검색 쿼리에 대한 mAP@k를 계산한다.
+     *
+     * @param k 상위 k개 결과까지만 평가
+     * @return mAP@k 값 (0.0 ~ 1.0)
+     */
+    fun calculateMapAtK(k: Int): Double {
+        val queries = searchClickLogPort.getAllSearchQueries()
+        if (queries.isEmpty()) return 0.0
+
+        val totalAp = queries.sumOf { query ->
+            val clickPositions = searchClickLogPort.getClickPositions(query)
+            calculateAveragePrecisionAtK(clickPositions, k)
+        }
+
+        val mapAtK = totalAp / queries.size
+        logger.debug("Calculated mAP@{}: {} (queries={})", k, mapAtK, queries.size)
+        return mapAtK
+    }
+
+    /**
+     * 단일 쿼리에 대한 AP@k를 계산한다.
+     *
+     * @param clickPositions 클릭된 위치 목록 (1-based, 정렬됨)
+     * @param k 상위 k개 결과까지만 평가
+     * @return AP@k 값 (0.0 ~ 1.0)
+     */
+    internal fun calculateAveragePrecisionAtK(clickPositions: List<Int>, k: Int): Double {
+        if (clickPositions.isEmpty()) return 0.0
+
+        val relevantInTopK = clickPositions.filter { it in 1..k }.toSet()
+        if (relevantInTopK.isEmpty()) return 0.0
+
+        var hits = 0
+        var sumPrecision = 0.0
+
+        for (i in 1..k) {
+            if (i in relevantInTopK) {
+                hits++
+                sumPrecision += hits.toDouble() / i
+            }
+        }
+
+        val m = clickPositions.size
+        return sumPrecision / minOf(m, k)
+    }
+}

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/RecordSearchClickUseCase.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/application/usecase/RecordSearchClickUseCase.kt
@@ -1,0 +1,28 @@
+package com.koosco.catalogservice.application.usecase
+
+import com.koosco.catalogservice.application.command.SearchClickCommand
+import com.koosco.catalogservice.application.port.SearchClickLogPort
+import com.koosco.common.core.annotation.UseCase
+import org.slf4j.LoggerFactory
+
+/**
+ * 검색 결과 클릭 로그를 기록하는 유스케이스.
+ * mAP@k 품질 지표 계산의 기반 데이터를 수집한다.
+ */
+@UseCase
+class RecordSearchClickUseCase(private val searchClickLogPort: SearchClickLogPort) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    fun execute(command: SearchClickCommand) {
+        searchClickLogPort.save(command)
+
+        logger.debug(
+            "Recorded search click: query={}, productId={}, position={}/{}",
+            command.searchQuery,
+            command.clickedProductId,
+            command.clickPosition,
+            command.totalResults,
+        )
+    }
+}

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/common/config/SearchQualityMetricsConfig.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/common/config/SearchQualityMetricsConfig.kt
@@ -1,0 +1,44 @@
+package com.koosco.catalogservice.common.config
+
+import com.koosco.catalogservice.application.usecase.CalculateSearchQualityUseCase
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Configuration
+
+/**
+ * 검색 품질 지표(mAP@k)를 Prometheus 메트릭으로 노출하는 설정.
+ * k=10, 30, 60에 대해 각각 Gauge를 등록한다.
+ */
+@Configuration
+class SearchQualityMetricsConfig(
+    private val meterRegistry: MeterRegistry,
+    private val calculateSearchQualityUseCase: CalculateSearchQualityUseCase,
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @PostConstruct
+    fun registerMetrics() {
+        K_VALUES.forEach { k ->
+            Gauge.builder("search.quality.map_at_k") {
+                try {
+                    calculateSearchQualityUseCase.calculateMapAtK(k)
+                } catch (e: Exception) {
+                    logger.warn("Failed to calculate mAP@{}: {}", k, e.message)
+                    0.0
+                }
+            }
+                .tag("k", k.toString())
+                .description("Mean Average Precision at k for search quality")
+                .register(meterRegistry)
+        }
+
+        logger.info("Registered search quality mAP@k metrics for k={}", K_VALUES)
+    }
+
+    companion object {
+        private val K_VALUES = listOf(10, 30, 60)
+    }
+}

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/redis/RedisSearchClickLogAdapter.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/infra/redis/RedisSearchClickLogAdapter.kt
@@ -1,0 +1,50 @@
+package com.koosco.catalogservice.infra.redis
+
+import com.koosco.catalogservice.application.command.SearchClickCommand
+import com.koosco.catalogservice.application.port.SearchClickLogPort
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+/**
+ * Redis 기반 검색 클릭 로그 저장소.
+ * Sorted Set을 사용하여 검색 쿼리별 클릭 위치를 저장한다.
+ * - key: catalog:search:click:{query}
+ * - member: {productId}:{position}
+ * - score: position (정렬용)
+ * TTL을 설정하여 오래된 데이터를 자동으로 정리한다.
+ */
+@Component
+class RedisSearchClickLogAdapter(private val redisTemplate: StringRedisTemplate) : SearchClickLogPort {
+
+    override fun save(command: SearchClickCommand) {
+        val key = clickKey(command.searchQuery)
+        val member = "${command.clickedProductId}:${command.clickPosition}"
+        val score = command.clickPosition.toDouble()
+
+        redisTemplate.opsForZSet().add(key, member, score)
+        redisTemplate.expire(key, TTL)
+    }
+
+    override fun getClickPositions(searchQuery: String): List<Int> {
+        val key = clickKey(searchQuery)
+        val members = redisTemplate.opsForZSet().rangeWithScores(key, 0, -1) ?: return emptyList()
+
+        return members
+            .mapNotNull { it.score?.toInt() }
+            .sorted()
+    }
+
+    override fun getAllSearchQueries(): Set<String> {
+        val pattern = "$KEY_PREFIX*"
+        val keys = redisTemplate.keys(pattern)
+        return keys.map { it.removePrefix(KEY_PREFIX) }.toSet()
+    }
+
+    companion object {
+        private const val KEY_PREFIX = "catalog:search:click:"
+        private val TTL = Duration.ofDays(7)
+
+        fun clickKey(query: String): String = "$KEY_PREFIX$query"
+    }
+}


### PR DESCRIPTION
## Summary
- 검색 클릭 로그 API (`POST /api/search/click`) 추가 및 Redis Sorted Set 저장
- mAP@k (Mean Average Precision at k) 계산 로직 구현 (k=10, 30, 60)
- Micrometer Gauge 메트릭으로 `search.quality.map_at_k` Prometheus 노출
- Grafana 대시보드 추가 (시계열 추이 + k별 게이지 패널)

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)