### PR TITLE
chore: JaCoCo 계층별 커버리지 검증 규칙 설정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ subprojects {
     tasks.withType<Test> {
         useJUnitPlatform()
         finalizedBy(tasks.withType<JacocoReport>())
+        finalizedBy(tasks.withType<JacocoCoverageVerification>())
     }
 
     tasks.withType<JacocoReport> {
@@ -38,6 +39,45 @@ subprojects {
             xml.required.set(true)
             html.required.set(true)
             csv.required.set(false)
+        }
+    }
+
+    tasks.withType<JacocoCoverageVerification> {
+        dependsOn(tasks.withType<JacocoReport>())
+
+        violationRules {
+            rule {
+                element = "CLASS"
+                includes = listOf("*.domain.*")
+                excludes = listOf(
+                    "*.api.*",
+                    "*.infra.*",
+                    "*.config.*",
+                    "*Application*",
+                    "*.contract.*",
+                    "*.common.*",
+                )
+                limit {
+                    counter = "LINE"
+                    minimum = "0.80".toBigDecimal()
+                }
+            }
+            rule {
+                element = "CLASS"
+                includes = listOf("*.application.*")
+                excludes = listOf(
+                    "*.api.*",
+                    "*.infra.*",
+                    "*.config.*",
+                    "*Application*",
+                    "*.contract.*",
+                    "*.common.*",
+                )
+                limit {
+                    counter = "LINE"
+                    minimum = "0.70".toBigDecimal()
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- domain 패키지 LINE 커버리지 80% 최소 기준 설정
- application 패키지 LINE 커버리지 70% 최소 기준 설정
- api, infra, config, contract, common 패키지 제외
- test 태스크에 jacocoTestCoverageVerification 연결

Closes #85

## Test plan
- [x] `./gradlew help` 정상 동작 확인
- [x] `jacocoTestCoverageVerification` dry-run 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)