### PR TITLE
refactor: @AuthId 인증 처리 통일 및 PublicEndpointProvider 정리

### DIFF
--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/BrandController.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/BrandController.kt
@@ -9,6 +9,7 @@ import com.koosco.catalogservice.application.usecase.DeleteBrandUseCase
 import com.koosco.catalogservice.application.usecase.GetBrandsUseCase
 import com.koosco.catalogservice.application.usecase.UpdateBrandUseCase
 import com.koosco.common.core.response.ApiResponse
+import com.koosco.commonsecurity.resolver.AuthId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
@@ -56,6 +57,7 @@ class BrandController(
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     fun createBrand(
+        @Parameter(hidden = true) @AuthId userId: Long,
         @Valid @RequestBody request: BrandCreateRequest,
         @RequestHeader("Idempotency-Key", required = false) idempotencyKey: String?,
     ): ApiResponse<BrandResponse> {
@@ -69,6 +71,7 @@ class BrandController(
     )
     @PutMapping("/{brandId}")
     fun updateBrand(
+        @Parameter(hidden = true) @AuthId userId: Long,
         @Parameter(description = "Brand ID") @PathVariable brandId: Long,
         @Valid @RequestBody request: BrandUpdateRequest,
     ): ApiResponse<Any> {
@@ -82,7 +85,10 @@ class BrandController(
     )
     @DeleteMapping("/{brandId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    fun deleteBrand(@Parameter(description = "Brand ID") @PathVariable brandId: Long): ApiResponse<Any> {
+    fun deleteBrand(
+        @Parameter(hidden = true) @AuthId userId: Long,
+        @Parameter(description = "Brand ID") @PathVariable brandId: Long,
+    ): ApiResponse<Any> {
         deleteBrandUseCase.execute(DeleteBrandCommand(brandId))
         return ApiResponse.success()
     }

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/CategoryController.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/CategoryController.kt
@@ -11,6 +11,7 @@ import com.koosco.catalogservice.application.usecase.GetCategoryByIdUseCase
 import com.koosco.catalogservice.application.usecase.GetCategoryListUseCase
 import com.koosco.catalogservice.application.usecase.GetCategoryTreeUseCase
 import com.koosco.common.core.response.ApiResponse
+import com.koosco.commonsecurity.resolver.AuthId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
@@ -79,6 +80,7 @@ class CategoryController(
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     fun createCategory(
+        @Parameter(hidden = true) @AuthId userId: Long,
         @Valid @RequestBody request: CategoryCreateRequest,
         @RequestHeader("Idempotency-Key", required = false) idempotencyKey: String?,
     ): ApiResponse<CategoryResponse> {
@@ -97,6 +99,7 @@ class CategoryController(
     @PostMapping("/tree")
     @ResponseStatus(HttpStatus.CREATED)
     fun createCategoryTree(
+        @Parameter(hidden = true) @AuthId userId: Long,
         @Valid @RequestBody request: CategoryTreeCreateRequest,
         @RequestHeader("Idempotency-Key", required = false) idempotencyKey: String?,
     ): ApiResponse<CategoryTreeResponse> {

--- a/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/ProductController.kt
+++ b/services/catalog-service/src/main/kotlin/com/koosco/catalogservice/api/controller/ProductController.kt
@@ -148,6 +148,7 @@ class ProductController(
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     fun createProduct(
+        @Parameter(hidden = true) @AuthId userId: Long,
         @Valid @RequestBody request: ProductCreateRequest,
         @RequestHeader("Idempotency-Key", required = false) idempotencyKey: String?,
     ): ApiResponse<ProductDetailResponse> {
@@ -163,6 +164,7 @@ class ProductController(
     )
     @PutMapping("/{productId}")
     fun updateProduct(
+        @Parameter(hidden = true) @AuthId userId: Long,
         @Parameter(description = "Product ID") @PathVariable productId: Long,
         @Valid @RequestBody request: ProductUpdateRequest,
     ): ApiResponse<Any> {
@@ -178,6 +180,7 @@ class ProductController(
     )
     @PatchMapping("/{productId}/status")
     fun changeProductStatus(
+        @Parameter(hidden = true) @AuthId userId: Long,
         @Parameter(description = "Product ID") @PathVariable productId: Long,
         @Valid @RequestBody request: ChangeStatusRequest,
     ): ApiResponse<Any> {
@@ -193,6 +196,7 @@ class ProductController(
     )
     @PostMapping("/{productId}/options")
     fun addProductOption(
+        @Parameter(hidden = true) @AuthId userId: Long,
         @Parameter(description = "Product ID") @PathVariable productId: Long,
         @Valid @RequestBody request: AddOptionRequest,
     ): ApiResponse<ProductDetailResponse> {
@@ -208,6 +212,7 @@ class ProductController(
     )
     @DeleteMapping("/{productId}/options/{optionId}")
     fun removeProductOption(
+        @Parameter(hidden = true) @AuthId userId: Long,
         @Parameter(description = "Product ID") @PathVariable productId: Long,
         @Parameter(description = "Option ID") @PathVariable optionId: Long,
     ): ApiResponse<ProductDetailResponse> {
@@ -225,7 +230,10 @@ class ProductController(
     )
     @DeleteMapping("/{productId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    fun deleteProduct(@Parameter(description = "Product ID") @PathVariable productId: Long): ApiResponse<Any> {
+    fun deleteProduct(
+        @Parameter(hidden = true) @AuthId userId: Long,
+        @Parameter(description = "Product ID") @PathVariable productId: Long,
+    ): ApiResponse<Any> {
         deleteProductUseCase.execute(DeleteProductCommand(productId = productId))
 
         return ApiResponse.Companion.success()

--- a/services/inventory-service/src/main/kotlin/com/koosco/inventoryservice/common/config/InventoryPublicEndpointProvider.kt
+++ b/services/inventory-service/src/main/kotlin/com/koosco/inventoryservice/common/config/InventoryPublicEndpointProvider.kt
@@ -1,21 +1,20 @@
 package com.koosco.inventoryservice.common.config
 
 import com.koosco.commonsecurity.config.PublicEndpointProvider
+import org.springframework.http.HttpMethod
 import org.springframework.stereotype.Component
 
-/**
- * fileName       : PaymentPublicEndpointProvider
- * author         : koo
- * date           : 2025. 12. 24. 오후 7:44
- * description    :
- */
 @Component
 class InventoryPublicEndpointProvider : PublicEndpointProvider {
+    override fun publicEndpointsByMethod(): Map<HttpMethod, Array<String>> = mapOf(
+        HttpMethod.GET to arrayOf("/api/inventories/{skuId}"),
+    )
+
     override fun publicEndpoints(): Array<String> = arrayOf(
-        "/**", // Public product browsing
-        "/actuator/health/**", // Kubernetes health checks
-        "/actuator/info", // Application info
-        "/swagger-ui/**", // API documentation
-        "/v3/api-docs/**", // OpenAPI specs
+        "/api/inventories/bulk",
+        "/actuator/health/**",
+        "/actuator/info",
+        "/swagger-ui/**",
+        "/v3/api-docs/**",
     )
 }

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/api/OrderController.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/api/OrderController.kt
@@ -79,8 +79,8 @@ class OrderController(
         description = "주문 상세 정보를 조회합니다. 주문 아이템 정보를 포함합니다.",
     )
     @GetMapping("/{orderId}")
-    fun getOrderDetail(@PathVariable orderId: Long): ApiResponse<OrderDetailResponse> {
-        val result = getOrderDetailUseCase.execute(orderId)
+    fun getOrderDetail(@AuthId userId: Long, @PathVariable orderId: Long): ApiResponse<OrderDetailResponse> {
+        val result = getOrderDetailUseCase.execute(orderId, userId)
         return ApiResponse.Companion.success(OrderDetailResponse.Companion.from(result))
     }
 

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/application/usecase/GetOrderDetailUseCase.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/application/usecase/GetOrderDetailUseCase.kt
@@ -1,17 +1,24 @@
 package com.koosco.orderservice.application.usecase
 
 import com.koosco.common.core.annotation.UseCase
+import com.koosco.common.core.exception.ForbiddenException
+import com.koosco.common.core.exception.NotFoundException
 import com.koosco.orderservice.application.port.OrderRepository
 import com.koosco.orderservice.application.result.OrderDetailResult
+import com.koosco.orderservice.common.error.OrderErrorCode
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class GetOrderDetailUseCase(private val orderRepository: OrderRepository) {
 
     @Transactional(readOnly = true)
-    fun execute(orderId: Long): OrderDetailResult {
+    fun execute(orderId: Long, userId: Long): OrderDetailResult {
         val order = orderRepository.findById(orderId)
-            ?: throw IllegalArgumentException("주문을 찾을 수 없습니다. orderId: $orderId")
+            ?: throw NotFoundException(OrderErrorCode.ORDER_NOT_FOUND)
+
+        if (order.userId != userId) {
+            throw ForbiddenException(OrderErrorCode.ORDER_ACCESS_DENIED)
+        }
 
         return OrderDetailResult.from(order)
     }

--- a/services/order-service/src/main/kotlin/com/koosco/orderservice/common/config/OrderPublicEndpointProvider.kt
+++ b/services/order-service/src/main/kotlin/com/koosco/orderservice/common/config/OrderPublicEndpointProvider.kt
@@ -6,13 +6,9 @@ import org.springframework.stereotype.Component
 @Component
 class OrderPublicEndpointProvider : PublicEndpointProvider {
     override fun publicEndpoints(): Array<String> = arrayOf(
-        "/**",
-//        "/api/orders/**", // Public product browsing
-//        "/api/carts/**", // Public category browsing
-//        "/api/coupons/**", // Public category browsing
-//        "/actuator/health/**", // Kubernetes health checks
-//        "/actuator/info", // Application info
-//        "/swagger-ui/**", // API documentation
-//        "/v3/api-docs/**", // OpenAPI specs
+        "/actuator/health/**",
+        "/actuator/info",
+        "/swagger-ui/**",
+        "/v3/api-docs/**",
     )
 }

--- a/services/payment-service/src/main/kotlin/com/koosco/paymentservice/common/PaymentPublicEndpointProvider.kt
+++ b/services/payment-service/src/main/kotlin/com/koosco/paymentservice/common/PaymentPublicEndpointProvider.kt
@@ -3,21 +3,14 @@ package com.koosco.paymentservice.common
 import com.koosco.commonsecurity.config.PublicEndpointProvider
 import org.springframework.stereotype.Component
 
-/**
- * fileName       : PaymentPublicEndpointProvider
- * author         : koo
- * date           : 2025. 12. 24. 오후 7:44
- * description    :
- */
 @Component
 class PaymentPublicEndpointProvider : PublicEndpointProvider {
     override fun publicEndpoints(): Array<String> = arrayOf(
-        "/test/**", // Public product browsing
-        "/api/carts/**", // Public category browsing
-        "/api/coupons/**", // Public category browsing
-        "/actuator/health/**", // Kubernetes health checks
-        "/actuator/info", // Application info
-        "/swagger-ui/**", // API documentation
-        "/v3/api-docs/**", // OpenAPI specs
+        "/api/payments/confirm",
+        "/api/payments/*/cancel",
+        "/actuator/health/**",
+        "/actuator/info",
+        "/swagger-ui/**",
+        "/v3/api-docs/**",
     )
 }


### PR DESCRIPTION
## Summary
- catalog-service: 쓰기 엔드포인트에 `@AuthId userId: Long` 파라미터 추가 (Product, Brand, Category)
- order-service: `getOrderDetail`에 `@AuthId` 추가 및 본인 주문 확인 검증 로직
- order-service: `OrderPublicEndpointProvider`에서 `/**` 와일드카드 제거, actuator/swagger만 공개
- inventory-service: `InventoryPublicEndpointProvider`에서 `/**` 제거, GET 조회와 bulk만 공개
- payment-service: `PaymentPublicEndpointProvider`에서 불필요 경로 제거, 결제 API만 공개 유지

Closes #86

## Test plan
- [x] `./gradlew :services:order-service:compileKotlin` 통과
- [x] `./gradlew :services:catalog-service:compileKotlin` 통과
- [x] `./gradlew :services:inventory-service:compileKotlin` 통과
- [x] `./gradlew :services:payment-service:compileKotlin` 통과
- [x] `./gradlew spotlessCheck` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)